### PR TITLE
Fixed gitignore to ignore executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # JSON Configuration data
 config.json
 
+# Executable File
+process
+
 # Test binary, build with `go test -c`
 *.test
 


### PR DESCRIPTION
In commit 353ee06c88fb67ade74a3715b4143abfff284606 most probably @codingo forgot to add his changes and commit. This pull request fixes that.