### PR TITLE
Fix #199

### DIFF
--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -12,7 +12,7 @@ import (
 )
 
 // EnumerateSingleDomain performs subdomain enumeration against a single domain
-func (r *Runner) EnumerateSingleDomain(domain, output string) error {
+func (r *Runner) EnumerateSingleDomain(domain, output string, overwrite bool) error {
 	log.Infof("Enumerating subdomains for %s\n", domain)
 
 	// Get the API keys for sources from the configuration
@@ -127,7 +127,15 @@ func (r *Runner) EnumerateSingleDomain(domain, output string) error {
 			}
 		}
 
-		file, err := os.Create(output)
+		var file *os.File
+		var err error
+
+		if overwrite {
+			file, err = os.Create(output)
+		} else {
+			file, err = os.OpenFile(output, os.O_APPEND | os.O_CREATE | os.O_WRONLY, 0644)
+		}
+
 		if err != nil {
 			log.Errorf("Could not create file %s for %s: %s\n", output, domain, err)
 			return err

--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -132,13 +132,16 @@ func (r *Runner) EnumerateSingleDomain(domain, output string, overwrite bool) er
 
 		if overwrite {
 			file, err = os.Create(output)
+			if err != nil {
+				log.Errorf("Could not create file %s for %s: %s\n", output, domain, err)
+				return err
+			}
 		} else {
 			file, err = os.OpenFile(output, os.O_APPEND | os.O_CREATE | os.O_WRONLY, 0644)
-		}
-
-		if err != nil {
-			log.Errorf("Could not create file %s for %s: %s\n", output, domain, err)
-			return err
+			if err != nil {
+				log.Errorf("Could not open file %s for %s: %s\n", output, domain, err)
+				return err
+			}
 		}
 
 		// Write the output to the file depending upon user requirement

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -40,7 +40,7 @@ func NewRunner(options *Options) (*Runner, error) {
 func (r *Runner) RunEnumeration() error {
 	// Check if only a single domain is sent as input. Process the domain now.
 	if r.options.Domain != "" {
-		return r.EnumerateSingleDomain(r.options.Domain, r.options.Output)
+		return r.EnumerateSingleDomain(r.options.Domain, r.options.Output, true)
 	}
 
 	// If we have multiple domains as input,
@@ -72,7 +72,7 @@ func (r *Runner) EnumerateMultipleDomains(reader io.Reader) error {
 		}
 
 		outputFile := path.Join(r.options.OutputDirectory, domain)
-		err := r.EnumerateSingleDomain(domain, outputFile)
+		err := r.EnumerateSingleDomain(domain, outputFile, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -71,8 +71,11 @@ func (r *Runner) EnumerateMultipleDomains(reader io.Reader) error {
 			continue
 		}
 
-		outputFile := path.Join(r.options.OutputDirectory, domain)
-		err := r.EnumerateSingleDomain(domain, outputFile, true)
+		outputFile := ""
+		if r.options.Output != "" {
+			outputFile = path.Join(r.options.OutputDirectory, r.options.Output)
+		}
+		err := r.EnumerateSingleDomain(domain, outputFile, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -65,7 +65,10 @@ func (r *Runner) RunEnumeration() error {
 // We keep enumerating subdomains for a given domain until we reach an error
 func (r *Runner) EnumerateMultipleDomains(reader io.Reader) error {
 	scanner := bufio.NewScanner(reader)
+	var scanned int = 0
 	for scanner.Scan() {
+		var isFirstRun bool = (scanned == 0)
+
 		domain := scanner.Text()
 		if domain == "" {
 			continue
@@ -75,10 +78,14 @@ func (r *Runner) EnumerateMultipleDomains(reader io.Reader) error {
 		if r.options.Output != "" {
 			outputFile = path.Join(r.options.OutputDirectory, r.options.Output)
 		}
-		err := r.EnumerateSingleDomain(domain, outputFile, false)
+
+		// the first enumeration will overwrite the output file,
+		// successive enumerations will append the results.
+		err := r.EnumerateSingleDomain(domain, outputFile, isFirstRun)
 		if err != nil {
 			return err
 		}
+		scanned++
 	}
 	return nil
 }


### PR DESCRIPTION
This is one way of solving issue #199: when multi-domain enumerations are performed, the output file is now overwritten at the first enumeration and successive enumerations will append the results instead.

This is consistent with the default behavior of overwriting the output file if the user supplied one.

Not sure if code style and/or the general idea fits the "subfinder" way of doing things though, let me know!