### PR TITLE
Fixed single file output

### DIFF
--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -12,7 +12,7 @@ import (
 )
 
 // EnumerateSingleDomain performs subdomain enumeration against a single domain
-func (r *Runner) EnumerateSingleDomain(domain, output string) error {
+func (r *Runner) EnumerateSingleDomain(domain, output string, append bool) error {
 	log.Infof("Enumerating subdomains for %s\n", domain)
 
 	// Get the API keys for sources from the configuration
@@ -127,7 +127,13 @@ func (r *Runner) EnumerateSingleDomain(domain, output string) error {
 			}
 		}
 
-		file, err := os.Create(output)
+		var file *os.File
+		var err error
+		if append {
+			file, err = os.OpenFile(output, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		} else {
+			file, err = os.Create(output)
+		}
 		if err != nil {
 			log.Errorf("Could not create file %s for %s: %s\n", output, domain, err)
 			return err

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -40,7 +40,7 @@ func NewRunner(options *Options) (*Runner, error) {
 func (r *Runner) RunEnumeration() error {
 	// Check if only a single domain is sent as input. Process the domain now.
 	if r.options.Domain != "" {
-		return r.EnumerateSingleDomain(r.options.Domain, r.options.Output)
+		return r.EnumerateSingleDomain(r.options.Domain, r.options.Output, false)
 	}
 
 	// If we have multiple domains as input,
@@ -71,8 +71,16 @@ func (r *Runner) EnumerateMultipleDomains(reader io.Reader) error {
 			continue
 		}
 
-		outputFile := path.Join(r.options.OutputDirectory, domain)
-		err := r.EnumerateSingleDomain(domain, outputFile)
+		var err error
+		// If the user has specifed an output file, use that output file instead
+		// of creating a new output file for each domain. Else create a new file
+		// for each domain in the directory.
+		if r.options.Output != "" {
+			err = r.EnumerateSingleDomain(domain, r.options.Output, true)
+		} else {
+			outputFile := path.Join(r.options.OutputDirectory, domain)
+			err = r.EnumerateSingleDomain(domain, outputFile, false)
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Using -o flag with a list of domains now allows you to write all output to a single file.