### PR TITLE
Improve error handling

### DIFF
--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -3,6 +3,7 @@ package subscraping
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"time"
 )
@@ -48,6 +49,9 @@ func (s *Session) NormalGetWithContext(ctx context.Context, url string) (*http.R
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode >= 400 {
+		return resp, fmt.Errorf("subscraping.NormalGetWithContext - %s returned status code %v", url, resp.StatusCode)
+	}
 
 	return resp, nil
 }
@@ -76,6 +80,9 @@ func (s *Session) Get(ctx context.Context, url string, cookies string, headers m
 	resp, err := s.Client.Do(req)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return resp, fmt.Errorf("subscraping.Get - %s returned status code %v", url, resp.StatusCode)
 	}
 
 	return resp, nil

--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -56,6 +56,22 @@ func (s *Session) NormalGetWithContext(ctx context.Context, url string) (*http.R
 	return resp, nil
 }
 
+// NormalGetWithRetriesWithContext makes a normal GET request to a URL, with the specified number of retries
+func (s *Session) NormalGetWithRetriesWithContext(ctx context.Context, url string, maxRetries int) (*http.Response, error) {
+	var resp *http.Response
+	var err error
+	for i := 0; i <= maxRetries; i++ {
+		if i > 0 {
+			time.Sleep(2 * time.Second)
+		}
+		resp, err = s.NormalGetWithContext(ctx, url)
+		if err == nil {
+			return resp, err
+		}
+	}
+	return nil, err
+}
+
 // Get makes a GET request to a URL
 func (s *Session) Get(ctx context.Context, url string, cookies string, headers map[string]string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)

--- a/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -2,6 +2,7 @@ package dnsdumpster
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -62,6 +63,9 @@ func postForm(token, domain string) (string, error) {
 	// Now, grab the entire page
 	in, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return string(in), fmt.Errorf("dnsdumpster.postForm - got status code %v", resp.StatusCode)
+	}
 	return string(in), err
 }
 

--- a/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -101,6 +101,12 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
+		if strings.Contains(data, "Too many requests") {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: fmt.Errorf("Too many requests from your IP address")}
+			close(results)
+			return
+		}
+
 		for _, subdomain := range session.Extractor.FindAllString(data, -1) {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 		}

--- a/pkg/subscraping/sources/hackertarget/hackertarget.go
+++ b/pkg/subscraping/sources/hackertarget/hackertarget.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/projectdiscovery/subfinder/pkg/subscraping"
 )
@@ -33,6 +34,12 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		}
 		resp.Body.Close()
 		src := string(body)
+
+		if strings.Contains(src, "API count exceeded") {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: fmt.Errorf("API count exceeded")}
+			close(results)
+			return
+		}
 
 		for _, match := range session.Extractor.FindAllString(src, -1) {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: match}

--- a/pkg/subscraping/sources/waybackarchive/waybackarchive.go
+++ b/pkg/subscraping/sources/waybackarchive/waybackarchive.go
@@ -9,6 +9,8 @@ import (
 	"github.com/projectdiscovery/subfinder/pkg/subscraping"
 )
 
+const maxRetries = 4
+
 // Source is the passive scraping agent
 type Source struct{}
 
@@ -17,7 +19,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		pagesResp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("http://web.archive.org/cdx/search/cdx?url=*.%s/*&output=json&fl=original&collapse=urlkey", domain))
+		pagesResp, err := session.NormalGetWithRetriesWithContext(ctx, fmt.Sprintf("http://web.archive.org/cdx/search/cdx?url=*.%s/*&output=json&fl=original&collapse=urlkey", domain), maxRetries)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			close(results)


### PR DESCRIPTION
Just a few little changes I made to help with error handling:

- if we get non 2xx response, assume our request failed and return an error
- add checks for specific errors returned by dnsdumpster and hackertarget (annoyingly they still return 2xx responses even in these cases)
- add retries for waybackarchive - I found that this helped a lot in reducing the overall error rates from this source