### PR TITLE
Small fix if $HOME/.config does not exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ shodan: []
 If you are using docker, you need to first create your directory structure holding subfinder configuration file. After modifying the default config.yaml file, you can run:
 
 ```bash
-> mkdir $HOME/.config/subfinder
+> mkdir -p $HOME/.config/subfinder
 > cp config.yaml $HOME/.config/subfinder/config.yaml
 > nano $HOME/.config/subfinder/config.yaml
 ```


### PR DESCRIPTION
Add -p to mkdir to prevent error message if .config does not exists