### PR TITLE
Handle GitHub Search API rate limit exceeded

### DIFF
--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -120,7 +120,7 @@ func (c ConfigFile) GetKeys() subscraping.Keys {
 		keys.DNSDB = c.DNSDB[rand.Intn(len(c.DNSDB))]
 	}
 	if (len(c.GitHub)) > 0 {
-		keys.GitHub = c.GitHub[rand.Intn(len(c.GitHub))]
+		keys.GitHub = c.GitHub
 	}
 
 	if len(c.IntelX) > 0 {

--- a/pkg/subscraping/sources/github/github.go
+++ b/pkg/subscraping/sources/github/github.go
@@ -150,7 +150,7 @@ func unique(arr []string) []string {
 // Domain regular expression to match subdomains in github files code
 func (s *Source) DomainRegexp(domain string) *regexp.Regexp {
 	rdomain := strings.Replace(domain, ".", "\\.", -1)
-	return regexp.MustCompile("[0-9a-z_\\-\\.]+\\." + rdomain)
+	return regexp.MustCompile("[\\w.]+\\." + rdomain)
 }
 
 // Raw URL to get the files code and match for subdomains

--- a/pkg/subscraping/sources/github/github.go
+++ b/pkg/subscraping/sources/github/github.go
@@ -77,7 +77,7 @@ func (s *Source) enumerate(ctx context.Context, searchURL string, domainRegexp *
 	ratelimitRemaining, _ := strconv.ParseInt(resp.Header.Get("X-Ratelimit-Remaining"), 10, 64)
 	if resp.StatusCode == http.StatusForbidden && ratelimitRemaining == 0 {
 		retryAfterSeconds, _ := strconv.ParseInt(resp.Header.Get("Retry-After"), 10, 64)
-		gologger.Verbosef("GitHub Search request rate limit reached, waiting for %s before retry \n", s.Name(), retryAfterSeconds)
+		gologger.Verbosef("GitHub Search request rate limit exceeded, waiting for %d seconds before retry... \n", s.Name(), retryAfterSeconds)
 
 		time.Sleep(time.Duration(retryAfterSeconds) * time.Second)
 		s.enumerate(ctx, searchURL, domainRegexp, session, results)

--- a/pkg/subscraping/sources/github/github.go
+++ b/pkg/subscraping/sources/github/github.go
@@ -181,7 +181,7 @@ func matches(regexp *regexp.Regexp, content string) []string {
 // Domain regular expression to match subdomains in github files code
 func (s *Source) DomainRegexp(domain string) *regexp.Regexp {
 	rdomain := strings.Replace(domain, ".", "\\.", -1)
-	return regexp.MustCompile("[\\w.]+\\." + rdomain)
+	return regexp.MustCompile("(\\w+[.])*" + rdomain)
 }
 
 // Raw URL to get the files code and match for subdomains

--- a/pkg/subscraping/sources/github/tokenmanager.go
+++ b/pkg/subscraping/sources/github/tokenmanager.go
@@ -1,0 +1,61 @@
+package github
+
+import "time"
+
+type token struct {
+	Hash         string
+	ExceededTime time.Time
+  RetryAfter int64
+}
+
+type Tokens struct {
+	current int
+	pool    []token
+}
+
+func NewTokenManager(keys []string) *Tokens {
+	pool := []token{}
+	for _, key := range keys {
+		t := token{Hash: key, ExceededTime: time.Time{}, RetryAfter: 0}
+		pool = append(pool, t)
+	}
+
+	return &Tokens{
+		current: 0,
+		pool:    pool,
+	}
+}
+
+func (r *Tokens) setCurrentTokenExceeded(retryAfter int64) {
+  if r.current >= len(r.pool) {
+		r.current = r.current % len(r.pool)
+	}
+  if r.pool[r.current].RetryAfter == 0 {
+    r.pool[r.current].ExceededTime = time.Now()
+    r.pool[r.current].RetryAfter = retryAfter
+  }
+}
+
+func (r *Tokens) Get() token {
+  resetExceededTokens(r)
+
+	if r.current >= len(r.pool) {
+		r.current = r.current % len(r.pool)
+	}
+
+	result := r.pool[r.current]
+	r.current++
+
+	return result
+}
+
+func resetExceededTokens(r *Tokens) {
+  for i, token := range r.pool {
+    if token.RetryAfter > 0 {
+      if int64(time.Since(token.ExceededTime) / time.Second) > token.RetryAfter {
+        r.pool[i].ExceededTime = time.Time{}
+        r.pool[i].RetryAfter = 0
+      }
+    }
+  }
+}

--- a/pkg/subscraping/sources/github/tokenmanager.go
+++ b/pkg/subscraping/sources/github/tokenmanager.go
@@ -4,8 +4,8 @@ import "time"
 
 type token struct {
 	Hash         string
+	RetryAfter   int64
 	ExceededTime time.Time
-  RetryAfter int64
 }
 
 type Tokens struct {
@@ -27,17 +27,17 @@ func NewTokenManager(keys []string) *Tokens {
 }
 
 func (r *Tokens) setCurrentTokenExceeded(retryAfter int64) {
-  if r.current >= len(r.pool) {
+	if r.current >= len(r.pool) {
 		r.current = r.current % len(r.pool)
 	}
-  if r.pool[r.current].RetryAfter == 0 {
-    r.pool[r.current].ExceededTime = time.Now()
-    r.pool[r.current].RetryAfter = retryAfter
-  }
+	if r.pool[r.current].RetryAfter == 0 {
+		r.pool[r.current].ExceededTime = time.Now()
+		r.pool[r.current].RetryAfter = retryAfter
+	}
 }
 
 func (r *Tokens) Get() token {
-  resetExceededTokens(r)
+	resetExceededTokens(r)
 
 	if r.current >= len(r.pool) {
 		r.current = r.current % len(r.pool)
@@ -50,12 +50,12 @@ func (r *Tokens) Get() token {
 }
 
 func resetExceededTokens(r *Tokens) {
-  for i, token := range r.pool {
-    if token.RetryAfter > 0 {
-      if int64(time.Since(token.ExceededTime) / time.Second) > token.RetryAfter {
-        r.pool[i].ExceededTime = time.Time{}
-        r.pool[i].RetryAfter = 0
-      }
-    }
-  }
+	for i, token := range r.pool {
+		if token.RetryAfter > 0 {
+			if int64(time.Since(token.ExceededTime)/time.Second) > token.RetryAfter {
+				r.pool[i].ExceededTime = time.Time{}
+				r.pool[i].RetryAfter = 0
+			}
+		}
+	}
 }

--- a/pkg/subscraping/types.go
+++ b/pkg/subscraping/types.go
@@ -35,7 +35,7 @@ type Keys struct {
 	Certspotter          string `json:"certspotter"`
 	Chaos                string `json:"chaos"`
 	DNSDB                string `json:"dnsdb"`
-	GitHub               string `json:"github"`
+	GitHub               []string `json:"github"`
 	IntelXHost           string `json:"intelXHost"`
 	IntelXKey            string `json:"intelXKey"`
 	PassiveTotalUsername string `json:"passivetotal_username"`


### PR DESCRIPTION
Fixes 

- #262: Support multiple GitHub tokens to randomly pick one to avoid exceeding request rate limit. Retry after `Retry-After` seconds header value if rate limit abuse is detected. 
- Bug iterating regex matches adds the first match only.

Implements

- Find subdomains using GitHub Search `text-match-metadata` too.
- Distributed use of the GitHub tokens.