### PR TITLE
Initial adoption of golangci-lint for continuous integration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,28 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.29
+          args: --timeout 5m
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -25,18 +47,3 @@ jobs:
       - name: Build
         run: go build .
         working-directory: cmd/subfinder/
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
-        with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,11 +4,11 @@ on:
     branches:
       - master
   pull_request:
-  
-jobs:          
+
+jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2
@@ -25,3 +25,18 @@ jobs:
       - name: Build
         run: go build .
         working-directory: cmd/subfinder/
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.29
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true

--- a/.github/workflows/dockerhub-push-on-release.yml
+++ b/.github/workflows/dockerhub-push-on-release.yml
@@ -1,7 +1,7 @@
 # dockerhub-push pushes docker build to dockerhub automatically
 # on the creation of a new release
 name: Publish to Dockerhub on creation of a new release
-on: 
+on:
   release:
     types: [published]
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,25 +4,25 @@ on:
     tags:
       - v*
 
-jobs: 
+jobs:
   release: 
     runs-on: ubuntu-latest
-    steps: 
-      - 
+    steps:
+      -
         name: "Check out code"
         uses: actions/checkout@v2
-        with: 
+        with:
           fetch-depth: 0
-      - 
+      -
         name: "Set up Go"
         uses: actions/setup-go@v2
-        with: 
+        with:
           go-version: 1.14
-      - 
-        env: 
+      -
+        env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         name: "Create release on GitHub"
         uses: goreleaser/goreleaser-action@v2
-        with: 
+        with:
           args: "release --rm-dist"
           version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,116 @@
+linters-settings:
+  dupl:
+    threshold: 100
+  exhaustive:
+    default-signifies-exhaustive: false
+  # funlen:
+  #   lines: 100
+  #   statements: 50
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+  # gocyclo:
+  #   min-complexity: 15
+  goimports:
+    local-prefixes: github.com/golangci/golangci-lint
+  golint:
+    min-confidence: 0
+  gomnd:
+    settings:
+      mnd:
+        # don't include the "operation" and "assign"
+        checks: argument,case,condition,return
+  govet:
+    check-shadowing: true
+    settings:
+      printf:
+        funcs:
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+  lll:
+    line-length: 140
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US
+  nolintlint:
+    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+linters:
+  # please, do not use `enable-all`: it's deprecated and will be removed soon.
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - dogsled
+    - dupl
+    - errcheck
+    - exhaustive
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gofmt
+    - goimports
+    - golint
+    - gomnd
+    - goprintffuncname
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - maligned
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - rowserrcheck
+    - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+
+  # don't enable:
+  # - depguard
+  # - asciicheck
+  # - funlen
+  # - gochecknoglobals
+  # - gocognit
+  # - gocyclo
+  # - godot
+  # - godox
+  # - goerr113
+  # - gosec
+  # - lll
+  # - nestif
+  # - prealloc
+  # - testpackage
+  # - wsl
+
+# golangci.com configuration
+# https://github.com/golangci/golangci/wiki/Configuration
+service:
+  golangci-lint-version: 1.29.x # use the fixed version to not introduce new linters unexpectedly
+  prepare:
+    - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,8 +39,8 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-  lll:
-    line-length: 140
+  # lll:
+  #   line-length: 140
   maligned:
     suggest-new: true
   misspell:

--- a/cmd/subfinder/main.go
+++ b/cmd/subfinder/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/subfinder/pkg/runner"
 )
@@ -14,7 +16,7 @@ func main() {
 		gologger.Fatalf("Could not create runner: %s\n", err)
 	}
 
-	err = newRunner.RunEnumeration()
+	err = newRunner.RunEnumeration(context.Background())
 	if err != nil {
 		gologger.Fatalf("Could not run enumeration: %s\n", err)
 	}

--- a/cmd/subfinder/main.go
+++ b/cmd/subfinder/main.go
@@ -9,12 +9,12 @@ func main() {
 	// Parse the command line flags and read config files
 	options := runner.ParseOptions()
 
-	runner, err := runner.NewRunner(options)
+	newRunner, err := runner.NewRunner(options)
 	if err != nil {
 		gologger.Fatalf("Could not create runner: %s\n", err)
 	}
 
-	err = runner.RunEnumeration()
+	err = newRunner.RunEnumeration()
 	if err != nil {
 		gologger.Fatalf("Could not run enumeration: %s\n", err)
 	}

--- a/pkg/passive/doc.go
+++ b/pkg/passive/doc.go
@@ -1,4 +1,3 @@
 // Package passive provides capability for doing passive subdomain
 // enumeration on targets.
 package passive
-

--- a/pkg/passive/passive.go
+++ b/pkg/passive/passive.go
@@ -11,7 +11,7 @@ import (
 )
 
 // EnumerateSubdomains enumerates all the subdomains for a given domain
-func (a *Agent) EnumerateSubdomains(domain string, keys subscraping.Keys, timeout int, maxEnumTime time.Duration) chan subscraping.Result {
+func (a *Agent) EnumerateSubdomains(domain string, keys *subscraping.Keys, timeout int, maxEnumTime time.Duration) chan subscraping.Result {
 	results := make(chan subscraping.Result)
 
 	go func() {

--- a/pkg/passive/passive.go
+++ b/pkg/passive/passive.go
@@ -36,7 +36,7 @@ func (a *Agent) EnumerateSubdomains(domain string, keys subscraping.Keys, timeou
 					results <- resp
 				}
 
-				duration := time.Now().Sub(now)
+				duration := time.Since(now)
 				timeTakenMutex.Lock()
 				timeTaken[source] = fmt.Sprintf("Source took %s for enumeration\n", duration)
 				timeTakenMutex.Unlock()

--- a/pkg/passive/sources.go
+++ b/pkg/passive/sources.go
@@ -85,7 +85,7 @@ func New(sources []string, exclusions []string) *Agent {
 }
 
 // addSources adds the given list of sources to the source array
-func (a *Agent) addSources(sources []string) {
+func (a *Agent) addSources(sources []string) { //nolint:funlen,addSources
 	for _, source := range sources {
 		switch source {
 		case "alienvault":

--- a/pkg/passive/sources.go
+++ b/pkg/passive/sources.go
@@ -74,7 +74,7 @@ type Agent struct {
 }
 
 // New creates a new agent for passive subdomain discovery
-func New(sources []string, exclusions []string) *Agent {
+func New(sources, exclusions []string) *Agent {
 	// Create the agent, insert the sources and remove the excluded sources
 	agent := &Agent{sources: make(map[string]subscraping.Source)}
 

--- a/pkg/passive/sources.go
+++ b/pkg/passive/sources.go
@@ -85,7 +85,7 @@ func New(sources, exclusions []string) *Agent {
 }
 
 // addSources adds the given list of sources to the source array
-func (a *Agent) addSources(sources []string) { //nolint:funlen,addSources
+func (a *Agent) addSources(sources []string) {
 	for _, source := range sources {
 		switch source {
 		case "alienvault":

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -101,7 +101,7 @@ func (r *ResolutionPool) resolveWorker() {
 
 		for _, host := range hosts {
 			// Ignore the host if it exists in wildcard ips map
-			if _, ok := r.wildcardIPs[host]; ok {
+			if _, ok := r.wildcardIPs[host]; ok { //nolint:staticcheck //search alternatives for "comma ok"
 				continue
 			}
 		}

--- a/pkg/runner/banners.go
+++ b/pkg/runner/banners.go
@@ -7,8 +7,8 @@ import (
 )
 
 const banner = `
-        _     __ _         _         
-____  _| |__ / _(_)_ _  __| |___ _ _ 
+        _     __ _         _
+____  _| |__ / _(_)_ _  __| |___ _ _
 (_-< || | '_ \  _| | ' \/ _  / -_) '_|
 /__/\_,_|_.__/_| |_|_||_\__,_\___|_| v2
 `
@@ -41,7 +41,7 @@ func (options *Options) firstRunTasks() {
 	// Create the configuration file and display information
 	// about it to the user.
 	config := ConfigFile{
-		// Use the default list of resolvers by marshalling it to the config
+		// Use the default list of resolvers by marshaling it to the config
 		Resolvers: resolve.DefaultResolvers,
 		// Use the default list of passive sources
 		Sources: passive.DefaultSources,

--- a/pkg/runner/chaosuploader.go
+++ b/pkg/runner/chaosuploader.go
@@ -1,16 +1,16 @@
 package runner
 
 import (
-  "context"
-  "crypto/tls"
-  "fmt"
-  "io"
-  "io/ioutil"
-  "net/http"
-  "time"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
 
-  "github.com/pkg/errors"
-  "github.com/projectdiscovery/gologger"
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
 )
 
 // UploadToChaosTimeoutNano timeout to upload to Chaos in nanoseconds

--- a/pkg/runner/chaosuploader.go
+++ b/pkg/runner/chaosuploader.go
@@ -1,0 +1,55 @@
+package runner
+
+import (
+  "context"
+  "crypto/tls"
+  "fmt"
+  "io"
+  "io/ioutil"
+  "net/http"
+  "time"
+
+  "github.com/pkg/errors"
+  "github.com/projectdiscovery/gologger"
+)
+
+// UploadToChaosTimeoutNano timeout to upload to Chaos in nanoseconds
+const UploadToChaosTimeoutNano = 600
+
+// UploadToChaos upload new data to Chaos dataset
+func (r *Runner) UploadToChaos(ctx context.Context, reader io.Reader) error {
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConnsPerHost: 100,
+			MaxIdleConns:        100,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+		Timeout: time.Duration(UploadToChaosTimeoutNano) * time.Second, // 10 minutes - uploads may take long
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", "https://dns.projectdiscovery.io/dns/add", reader)
+	if err != nil {
+		return errors.Wrap(err, "could not create request")
+	}
+	request.Header.Set("Authorization", r.options.YAMLConfig.GetKeys().Chaos)
+
+	resp, err := httpClient.Do(request)
+	if err != nil {
+		return errors.Wrap(err, "could not make request")
+	}
+	defer func() {
+		_, err := io.Copy(ioutil.Discard, resp.Body)
+		if err != nil {
+			gologger.Warningf("Could not discard response body: %s\n", err)
+			return
+		}
+		resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("invalid status code received: %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -10,6 +10,12 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// MultipleKeyPartsLength is the max length for multiple keys
+const MultipleKeyPartsLength = 2
+
+// YAMLIndentCharLength number of chars for identation on write YAML to file
+const YAMLIndentCharLength = 4
+
 // ConfigFile contains the fields stored in the configuration file
 type ConfigFile struct {
 	// Resolvers contains the list of resolvers to use while resolving
@@ -72,7 +78,7 @@ func (c ConfigFile) MarshalWrite(file string) error {
 
 	// Indent the spaces too
 	enc := yaml.NewEncoder(f)
-	enc.SetIndent(4)
+	enc.SetIndent(YAMLIndentCharLength)
 	err = enc.Encode(&c)
 	f.Close()
 	return err
@@ -104,7 +110,7 @@ func (c ConfigFile) GetKeys() subscraping.Keys {
 	if len(c.Censys) > 0 {
 		censysKeys := c.Censys[rand.Intn(len(c.Censys))]
 		parts := strings.Split(censysKeys, ":")
-		if len(parts) == 2 {
+		if len(parts) == MultipleKeyPartsLength {
 			keys.CensysToken = parts[0]
 			keys.CensysSecret = parts[1]
 		}
@@ -126,7 +132,7 @@ func (c ConfigFile) GetKeys() subscraping.Keys {
 	if len(c.IntelX) > 0 {
 		intelxKeys := c.IntelX[rand.Intn(len(c.IntelX))]
 		parts := strings.Split(intelxKeys, ":")
-		if len(parts) == 2 {
+		if len(parts) == MultipleKeyPartsLength {
 			keys.IntelXHost = parts[0]
 			keys.IntelXKey = parts[1]
 		}
@@ -135,7 +141,7 @@ func (c ConfigFile) GetKeys() subscraping.Keys {
 	if len(c.PassiveTotal) > 0 {
 		passiveTotalKeys := c.PassiveTotal[rand.Intn(len(c.PassiveTotal))]
 		parts := strings.Split(passiveTotalKeys, ":")
-		if len(parts) == 2 {
+		if len(parts) == MultipleKeyPartsLength {
 			keys.PassiveTotalUsername = parts[0]
 			keys.PassiveTotalPassword = parts[1]
 		}
@@ -159,7 +165,7 @@ func (c ConfigFile) GetKeys() subscraping.Keys {
 	if len(c.ZoomEye) > 0 {
 		zoomEyeKeys := c.ZoomEye[rand.Intn(len(c.ZoomEye))]
 		parts := strings.Split(zoomEyeKeys, ":")
-		if len(parts) == 2 {
+		if len(parts) == MultipleKeyPartsLength {
 			keys.ZoomEyeUsername = parts[0]
 			keys.ZoomEyePassword = parts[1]
 		}

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -53,8 +53,12 @@ func GetConfigDirectory() (string, error) {
 		return config, err
 	}
 	config = directory + "/.config/subfinder"
+
 	// Create All directory for subfinder even if they exist
-	os.MkdirAll(config, os.ModePerm)
+	err = os.MkdirAll(config, os.ModePerm)
+	if err != nil {
+		return config, err
+	}
 
 	return config, nil
 }

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -70,7 +70,7 @@ func CheckConfigExists(configPath string) bool {
 }
 
 // MarshalWrite writes the marshaled yaml config to disk
-func (c ConfigFile) MarshalWrite(file string) error {
+func (c *ConfigFile) MarshalWrite(file string) error {
 	f, err := os.OpenFile(file, os.O_WRONLY|os.O_CREATE, 0755)
 	if err != nil {
 		return err
@@ -100,7 +100,7 @@ func UnmarshalRead(file string) (ConfigFile, error) {
 // GetKeys gets the API keys from config file and creates a Keys struct
 // We use random selection of api keys from the list of keys supplied.
 // Keys that require 2 options are separated by colon (:).
-func (c ConfigFile) GetKeys() subscraping.Keys {
+func (c *ConfigFile) GetKeys() subscraping.Keys {
 	keys := subscraping.Keys{}
 
 	if len(c.Binaryedge) > 0 {

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -69,7 +69,7 @@ func CheckConfigExists(configPath string) bool {
 	return false
 }
 
-// MarshalWrite writes the marshalled yaml config to disk
+// MarshalWrite writes the marshaled yaml config to disk
 func (c ConfigFile) MarshalWrite(file string) error {
 	f, err := os.OpenFile(file, os.O_WRONLY|os.O_CREATE, 0755)
 	if err != nil {

--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -33,7 +33,7 @@ func (r *Runner) EnumerateSingleDomain(domain, output string, append bool) error
 	}
 
 	// Run the passive subdomain enumeration
-	passiveResults := r.passiveAgent.EnumerateSubdomains(domain, keys, r.options.Timeout, time.Duration(r.options.MaxEnumerationTime)*time.Minute)
+	passiveResults := r.passiveAgent.EnumerateSubdomains(domain, &keys, r.options.Timeout, time.Duration(r.options.MaxEnumerationTime)*time.Minute)
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)

--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -118,7 +118,7 @@ func (r *Runner) EnumerateSingleDomain(domain, output string, append bool) error
 	if r.options.ChaosUpload {
 		var buf = &bytes.Buffer{}
 		err := WriteHostOutput(uniqueMap, buf)
-		// If an error occurs, do not interrupt, continue to check if user specifed an output file
+		// If an error occurs, do not interrupt, continue to check if user specified an output file
 		if err != nil {
 			gologger.Errorf("Could not prepare results for chaos %s\n", err)
 		} else {

--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -14,7 +14,7 @@ import (
 )
 
 // EnumerateSingleDomain performs subdomain enumeration against a single domain
-func (r *Runner) EnumerateSingleDomain(ctx context.Context, domain, output string, append bool) error {
+func (r *Runner) EnumerateSingleDomain(ctx context.Context, domain, output string, appendToFile bool) error {
 	gologger.Infof("Enumerating subdomains for %s\n", domain)
 
 	// Get the API keys for sources from the configuration
@@ -149,7 +149,7 @@ func (r *Runner) EnumerateSingleDomain(ctx context.Context, domain, output strin
 
 		var file *os.File
 		var err error
-		if append {
+		if appendToFile {
 			file, err = os.OpenFile(output, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		} else {
 			file, err = os.Create(output)

--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -130,7 +130,7 @@ func (r *Runner) EnumerateSingleDomain(domain, output string, append bool) error
 				gologger.Infof("Input processed successfully and subdomains with valid records will be updated to chaos dataset.\n")
 			}
 			// clear buffer
-			buf = nil
+			buf.Reset()
 		}
 	}
 	// In case the user has given an output file, write all the found

--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"strings"
 	"sync"
@@ -13,7 +14,7 @@ import (
 )
 
 // EnumerateSingleDomain performs subdomain enumeration against a single domain
-func (r *Runner) EnumerateSingleDomain(domain, output string, append bool) error {
+func (r *Runner) EnumerateSingleDomain(ctx context.Context, domain, output string, append bool) error {
 	gologger.Infof("Enumerating subdomains for %s\n", domain)
 
 	// Get the API keys for sources from the configuration
@@ -123,7 +124,7 @@ func (r *Runner) EnumerateSingleDomain(domain, output string, append bool) error
 			gologger.Errorf("Could not prepare results for chaos %s\n", err)
 		} else {
 			// no error in writing host output, upload to chaos
-			err = r.UploadToChaos(buf)
+			err = r.UploadToChaos(ctx, buf)
 			if err != nil {
 				gologger.Errorf("Could not upload results to chaos %s\n", err)
 			} else {

--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -140,9 +140,9 @@ func (r *Runner) EnumerateSingleDomain(domain, output string, append bool) error
 		// else append .txt
 		if r.options.OutputDirectory != "" {
 			if r.options.JSON {
-				output = output + ".json"
+				output += ".json"
 			} else {
-				output = output + ".txt"
+				output += ".txt"
 			}
 		}
 

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -130,13 +130,13 @@ func listSources(options *Options) {
 	needsKey := make(map[string]interface{})
 	keysElem := reflect.ValueOf(&keys).Elem()
 	for i := 0; i < keysElem.NumField(); i++ {
-			needsKey[strings.ToLower(keysElem.Type().Field(i).Name)] = keysElem.Field(i).Interface()
+		needsKey[strings.ToLower(keysElem.Type().Field(i).Name)] = keysElem.Field(i).Interface()
 	}
 
 	for _, source := range options.YAMLConfig.Sources {
 		message := "%s\n"
 		if _, ok := needsKey[source]; ok {
-				message = "%s *\n"
+			message = "%s *\n"
 		}
 		gologger.Silentf(message, source)
 	}

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -15,26 +15,26 @@ import (
 type Options struct {
 	Verbose            bool   // Verbose flag indicates whether to show verbose output or not
 	NoColor            bool   // No-Color disables the colored output
+	ChaosUpload        bool   // ChaosUpload indicates whether to upload results to the Chaos API
+	JSON               bool   // JSON specifies whether to use json for output format or text file
+	HostIP             bool   // HostIP specifies whether to write subdomains in host:ip format
+	Silent             bool   // Silent suppresses any extra text and only writes subdomains to screen
+	ListSources        bool   // ListSources specifies whether to list all available sources
+	RemoveWildcard     bool   // RemoveWildcard specifies whether to remove potential wildcard or dead subdomains from the results.
+	Stdin              bool   // Stdin specifies whether stdin input was given to the process
+	Version            bool   // Version specifies if we should just show version and exit
 	Threads            int    // Thread controls the number of threads to use for active enumerations
 	Timeout            int    // Timeout is the seconds to wait for sources to respond
 	MaxEnumerationTime int    // MaxEnumerationTime is the maximum amount of time in mins to wait for enumeration
 	Domain             string // Domain is the domain to find subdomains for
 	DomainsFile        string // DomainsFile is the file containing list of domains to find subdomains for
-	ChaosUpload        bool   // ChaosUpload indicates whether to upload results to the Chaos API
 	Output             string // Output is the file to write found subdomains to.
 	OutputDirectory    string // OutputDirectory is the directory to write results to in case list of domains is given
-	JSON               bool   // JSON specifies whether to use json for output format or text file
-	HostIP             bool   // HostIP specifies whether to write subdomains in host:ip format
-	Silent             bool   // Silent suppresses any extra text and only writes subdomains to screen
 	Sources            string // Sources contains a comma-separated list of sources to use for enumeration
-	ListSources        bool   // ListSources specifies whether to list all available sources
 	ExcludeSources     string // ExcludeSources contains the comma-separated sources to not include in the enumeration process
 	Resolvers          string // Resolvers is the comma-separated resolvers to use for enumeration
 	ResolverList       string // ResolverList is a text file containing list of resolvers to use for enumeration
-	RemoveWildcard     bool   // RemoveWildcard specifies whether to remove potential wildcard or dead subdomains from the results.
 	ConfigFile         string // ConfigFile contains the location of the config file
-	Stdin              bool   // Stdin specifies whether stdin input was given to the process
-	Version            bool   // Version specifies if we should just show version and exit
 
 	YAMLConfig ConfigFile // YAMLConfig contains the unmarshalled yaml config file
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -72,7 +72,7 @@ func (r *Runner) EnumerateMultipleDomains(reader io.Reader) error {
 		}
 
 		var err error
-		// If the user has specifed an output file, use that output file instead
+		// If the user has specified an output file, use that output file instead
 		// of creating a new output file for each domain. Else create a new file
 		// for each domain in the directory.
 		if r.options.Output != "" {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"os"
 	"path"
@@ -37,10 +38,10 @@ func NewRunner(options *Options) (*Runner, error) {
 }
 
 // RunEnumeration runs the subdomain enumeration flow on the targets specified
-func (r *Runner) RunEnumeration() error {
+func (r *Runner) RunEnumeration(ctx context.Context) error {
 	// Check if only a single domain is sent as input. Process the domain now.
 	if r.options.Domain != "" {
-		return r.EnumerateSingleDomain(r.options.Domain, r.options.Output, false)
+		return r.EnumerateSingleDomain(ctx, r.options.Domain, r.options.Output, false)
 	}
 
 	// If we have multiple domains as input,
@@ -49,21 +50,21 @@ func (r *Runner) RunEnumeration() error {
 		if err != nil {
 			return err
 		}
-		err = r.EnumerateMultipleDomains(f)
+		err = r.EnumerateMultipleDomains(ctx, f)
 		f.Close()
 		return err
 	}
 
 	// If we have STDIN input, treat it as multiple domains
 	if r.options.Stdin {
-		return r.EnumerateMultipleDomains(os.Stdin)
+		return r.EnumerateMultipleDomains(ctx, os.Stdin)
 	}
 	return nil
 }
 
 // EnumerateMultipleDomains enumerates subdomains for multiple domains
 // We keep enumerating subdomains for a given domain until we reach an error
-func (r *Runner) EnumerateMultipleDomains(reader io.Reader) error {
+func (r *Runner) EnumerateMultipleDomains(ctx context.Context, reader io.Reader) error {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		domain := scanner.Text()
@@ -76,12 +77,12 @@ func (r *Runner) EnumerateMultipleDomains(reader io.Reader) error {
 		// of creating a new output file for each domain. Else create a new file
 		// for each domain in the directory.
 		if r.options.Output != "" {
-			err = r.EnumerateSingleDomain(domain, r.options.Output, true)
+			err = r.EnumerateSingleDomain(ctx, domain, r.options.Output, true)
 		} else if r.options.OutputDirectory != "" {
 			outputFile := path.Join(r.options.OutputDirectory, domain)
-			err = r.EnumerateSingleDomain(domain, outputFile, false)
+			err = r.EnumerateSingleDomain(ctx, domain, outputFile, false)
 		} else {
-			err = r.EnumerateSingleDomain(domain, "", true)
+			err = r.EnumerateSingleDomain(ctx, domain, "", true)
 		}
 		if err != nil {
 			return err

--- a/pkg/runner/utils.go
+++ b/pkg/runner/utils.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"bufio"
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -25,7 +26,7 @@ type JSONResult struct {
 }
 
 // UploadToChaos upload new data to Chaos dataset
-func (r *Runner) UploadToChaos(reader io.Reader) error {
+func (r *Runner) UploadToChaos(ctx context.Context, reader io.Reader) error {
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			MaxIdleConnsPerHost: 100,
@@ -37,7 +38,7 @@ func (r *Runner) UploadToChaos(reader io.Reader) error {
 		Timeout: time.Duration(UploadToChaosTimeoutNano) * time.Second, // 10 minutes - uploads may take long
 	}
 
-	request, err := http.NewRequest("POST", "https://dns.projectdiscovery.io/dns/add", reader)
+	request, err := http.NewRequestWithContext(ctx, "POST", "https://dns.projectdiscovery.io/dns/add", reader)
 	if err != nil {
 		return errors.Wrap(err, "could not create request")
 	}

--- a/pkg/runner/utils.go
+++ b/pkg/runner/utils.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/projectdiscovery/gologger"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
 )
 
 // UploadToChaosTimeoutNano timeout to upload to Chaos in nanoseconds

--- a/pkg/runner/utils.go
+++ b/pkg/runner/utils.go
@@ -50,7 +50,7 @@ func (r *Runner) UploadToChaos(reader io.Reader) error {
 	defer func() {
 		_, err := io.Copy(ioutil.Discard, resp.Body)
 		if err != nil {
-			gologger.Warningf("Could not discard response body.", err)
+			gologger.Warningf("Could not discard response body: %s\n", err)
 			return
 		}
 		resp.Body.Close()

--- a/pkg/runner/utils.go
+++ b/pkg/runner/utils.go
@@ -14,6 +14,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// UploadToChaosTimeoutNano timeout to upload to Chaos in nanoseconds
+const UploadToChaosTimeoutNano = 600
+
 // JSONResult contains the result for a host in JSON format
 type JSONResult struct {
 	Host string `json:"host"`
@@ -29,7 +32,7 @@ func (r *Runner) UploadToChaos(reader io.Reader) error {
 				InsecureSkipVerify: true,
 			},
 		},
-		Timeout: time.Duration(600) * time.Second, // 10 minutes - uploads may take long
+		Timeout: time.Duration(UploadToChaosTimeoutNano) * time.Second, // 10 minutes - uploads may take long
 	}
 
 	request, err := http.NewRequest("POST", "https://dns.projectdiscovery.io/dns/add", reader)
@@ -47,7 +50,7 @@ func (r *Runner) UploadToChaos(reader io.Reader) error {
 		resp.Body.Close()
 	}()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("invalid status code received: %d", resp.StatusCode)
 	}
 	return nil

--- a/pkg/runner/utils.go
+++ b/pkg/runner/utils.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/projectdiscovery/gologger"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -23,6 +24,7 @@ type JSONResult struct {
 	IP   string `json:"ip"`
 }
 
+// UploadToChaos upload new data to Chaos dataset
 func (r *Runner) UploadToChaos(reader io.Reader) error {
 	httpClient := &http.Client{
 		Transport: &http.Transport{
@@ -46,7 +48,11 @@ func (r *Runner) UploadToChaos(reader io.Reader) error {
 		return errors.Wrap(err, "could not make request")
 	}
 	defer func() {
-		io.Copy(ioutil.Discard, resp.Body)
+		_, err := io.Copy(ioutil.Discard, resp.Body)
+		if err != nil {
+			gologger.Warningf("Could not discard response body.", err)
+			return
+		}
 		resp.Body.Close()
 	}()
 

--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/projectdiscovery/gologger"
 )
 
 // NewSession creates a new session object for a domain
@@ -76,7 +78,11 @@ func (s *Session) Get(ctx context.Context, getURL string, cookies string, header
 // DiscardHTTPResponse discards the response content by demand
 func (s *Session) DiscardHTTPResponse(response *http.Response) {
 	if response != nil {
-		io.Copy(ioutil.Discard, response.Body)
+		_, err := io.Copy(ioutil.Discard, response.Body)
+		if err != nil {
+			gologger.Warningf("Could not discard response body.", err)
+			return
+		}
 		response.Body.Close()
 	}
 }

--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -12,7 +12,7 @@ import (
 )
 
 // NewSession creates a new session object for a domain
-func NewSession(domain string, keys Keys, timeout int) (*Session, error) {
+func NewSession(domain string, keys *Keys, timeout int) (*Session, error) {
 	client := &http.Client{
 		Transport: &http.Transport{
 			MaxIdleConns:        100,

--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -54,7 +54,7 @@ func (s *Session) NormalGetWithContext(ctx context.Context, getURL string) (*htt
 }
 
 // Get makes a GET request to a URL
-func (s *Session) Get(ctx context.Context, getURL string, cookies string, headers map[string]string) (*http.Response, error) {
+func (s *Session) Get(ctx context.Context, getURL, cookies string, headers map[string]string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", getURL, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -80,7 +80,7 @@ func (s *Session) DiscardHTTPResponse(response *http.Response) {
 	if response != nil {
 		_, err := io.Copy(ioutil.Discard, response.Body)
 		if err != nil {
-			gologger.Warningf("Could not discard response body.", err)
+			gologger.Warningf("Could not discard response body: %s\n", err)
 			return
 		}
 		response.Body.Close()

--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -66,10 +66,8 @@ func (s *Session) Get(ctx context.Context, url string, cookies string, headers m
 		req.Header.Set("Cookie", cookies)
 	}
 
-	if headers != nil {
-		for key, value := range headers {
-			req.Header.Set(key, value)
-		}
+	for key, value := range headers {
+		req.Header.Set(key, value)
 	}
 
 	return httpRequestWrapper(s.Client, req)

--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -73,7 +73,8 @@ func (s *Session) Get(ctx context.Context, url string, cookies string, headers m
 	return httpRequestWrapper(s.Client, req)
 }
 
-func (s *Session) DiscardHttpResponse(response *http.Response) {
+// DiscardHTTPResponse discards the response content by demand
+func (s *Session) DiscardHTTPResponse(response *http.Response) {
 	if response != nil {
 		io.Copy(ioutil.Discard, response.Body)
 		response.Body.Close()
@@ -87,8 +88,8 @@ func httpRequestWrapper(client *http.Client, request *http.Request) (*http.Respo
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		requestUrl, _ := url.QueryUnescape(request.URL.String())
-		return resp, fmt.Errorf("Unexpected status code %d received from %s", resp.StatusCode, requestUrl)
+		requestURL, _ := url.QueryUnescape(request.URL.String())
+		return resp, fmt.Errorf("unexpected status code %d received from %s", resp.StatusCode, requestURL)
 	}
 	return resp, nil
 }

--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -37,8 +37,8 @@ func NewSession(domain string, keys *Keys, timeout int) (*Session, error) {
 }
 
 // NormalGetWithContext makes a normal GET request to a URL with context
-func (s *Session) NormalGetWithContext(ctx context.Context, url string) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+func (s *Session) NormalGetWithContext(ctx context.Context, getURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", getURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +52,8 @@ func (s *Session) NormalGetWithContext(ctx context.Context, url string) (*http.R
 }
 
 // Get makes a GET request to a URL
-func (s *Session) Get(ctx context.Context, url string, cookies string, headers map[string]string) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+func (s *Session) Get(ctx context.Context, getURL string, cookies string, headers map[string]string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", getURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/subscraping/sources/alienvault/alienvault.go
+++ b/pkg/subscraping/sources/alienvault/alienvault.go
@@ -25,7 +25,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://otx.alienvault.com/api/v1/indicators/domain/%s/passive_dns", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/alienvault/alienvault.go
+++ b/pkg/subscraping/sources/alienvault/alienvault.go
@@ -22,7 +22,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://otx.alienvault.com/api/v1/indicators/domain/%s/passive_dns", domain))
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://otx.alienvault.com/api/v1/indicators/domain/%s/passive_dns", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/archiveis/archiveis.go
+++ b/pkg/subscraping/sources/archiveis/archiveis.go
@@ -27,7 +27,7 @@ func (a *ArchiveIs) enumerate(ctx context.Context, baseURL string) {
 	resp, err := a.Session.NormalGetWithContext(ctx, baseURL)
 	if err != nil {
 		a.Results <- subscraping.Result{Source: "archiveis", Type: subscraping.Error, Error: err}
-		a.Session.DiscardHttpResponse(resp)
+		a.Session.DiscardHTTPResponse(resp)
 		return
 	}
 

--- a/pkg/subscraping/sources/archiveis/archiveis.go
+++ b/pkg/subscraping/sources/archiveis/archiveis.go
@@ -24,7 +24,7 @@ func (a *ArchiveIs) enumerate(ctx context.Context, baseURL string) {
 	default:
 	}
 
-	resp, err := a.Session.NormalGetWithContext(ctx, baseURL)
+	resp, err := a.Session.SimpleGet(ctx, baseURL)
 	if err != nil {
 		a.Results <- subscraping.Result{Source: "archiveis", Type: subscraping.Error, Error: err}
 		a.Session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/binaryedge/binaryedge.go
+++ b/pkg/subscraping/sources/binaryedge/binaryedge.go
@@ -93,7 +93,7 @@ func (s *Source) getSubdomains(ctx context.Context, domain string, remaining, cu
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 			}
 
-			*remaining = *remaining - 100
+			*remaining -= 100
 			if *remaining <= 0 {
 				return false
 			}

--- a/pkg/subscraping/sources/binaryedge/binaryedge.go
+++ b/pkg/subscraping/sources/binaryedge/binaryedge.go
@@ -29,7 +29,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.Get(ctx, fmt.Sprintf("https://api.binaryedge.io/v2/query/domains/subdomain/%s", domain), "", map[string]string{"X-Key": session.Keys.Binaryedge})
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/bufferover/bufferover.go
+++ b/pkg/subscraping/sources/bufferover/bufferover.go
@@ -27,8 +27,8 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	return results
 }
 
-func (s *Source) getData(ctx context.Context, URL string, session *subscraping.Session, results chan subscraping.Result) {
-	resp, err := session.NormalGetWithContext(ctx, URL)
+func (s *Source) getData(ctx context.Context, sourceURL string, session *subscraping.Session, results chan subscraping.Result) {
+	resp, err := session.NormalGetWithContext(ctx, sourceURL)
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 		session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/bufferover/bufferover.go
+++ b/pkg/subscraping/sources/bufferover/bufferover.go
@@ -28,7 +28,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 }
 
 func (s *Source) getData(ctx context.Context, sourceURL string, session *subscraping.Session, results chan subscraping.Result) {
-	resp, err := session.NormalGetWithContext(ctx, sourceURL)
+	resp, err := session.SimpleGet(ctx, sourceURL)
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 		session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/bufferover/bufferover.go
+++ b/pkg/subscraping/sources/bufferover/bufferover.go
@@ -31,7 +31,7 @@ func (s *Source) getData(ctx context.Context, URL string, session *subscraping.S
 	resp, err := session.NormalGetWithContext(ctx, URL)
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-		session.DiscardHttpResponse(resp)
+		session.DiscardHTTPResponse(resp)
 		return
 	}
 

--- a/pkg/subscraping/sources/bufferover/bufferover.go
+++ b/pkg/subscraping/sources/bufferover/bufferover.go
@@ -48,7 +48,6 @@ func (s *Source) getData(ctx context.Context, URL string, session *subscraping.S
 	for _, subdomain := range session.Extractor.FindAllString(src, -1) {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 	}
-	return
 }
 
 // Name returns the name of the source

--- a/pkg/subscraping/sources/censys/censys.go
+++ b/pkg/subscraping/sources/censys/censys.go
@@ -3,7 +3,6 @@ package censys
 import (
 	"bytes"
 	"context"
-	"net/http"
 	"strconv"
 
 	jsoniter "github.com/json-iterator/go"
@@ -42,19 +41,19 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		for {
 			var request = []byte(`{"query":"` + domain + `", "page":` + strconv.Itoa(currentPage) + `, "fields":["parsed.names","parsed.extensions.subject_alt_name.dns_names"], "flatten":true}`)
 
-			req, err := http.NewRequestWithContext(ctx, "POST", "https://www.censys.io/api/v1/search/certificates", bytes.NewReader(request))
-			if err != nil {
-				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-				close(results)
-				return
-			}
-			req.SetBasicAuth(session.Keys.CensysToken, session.Keys.CensysSecret)
-			req.Header.Set("Content-Type", "application/json")
-			req.Header.Set("Accept", "application/json")
+			resp, err := session.HTTPRequest(
+				ctx,
+				"POST",
+				"https://www.censys.io/api/v1/search/certificates",
+				"",
+				map[string]string{"Content-Type": "application/json", "Accept": "application/json"},
+				bytes.NewReader(request),
+				subscraping.BasicAuth{Username: session.Keys.CensysToken, Password: session.Keys.CensysSecret},
+			)
 
-			resp, err := session.Client.Do(req)
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+				session.DiscardHTTPResponse(resp)
 				close(results)
 				return
 			}

--- a/pkg/subscraping/sources/censys/censys.go
+++ b/pkg/subscraping/sources/censys/censys.go
@@ -36,7 +36,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			close(results)
 			return
 		}
-		var response response
+		var censysResponse response
 
 		currentPage := 1
 		for {
@@ -59,7 +59,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				return
 			}
 
-			err = jsoniter.NewDecoder(resp.Body).Decode(&response)
+			err = jsoniter.NewDecoder(resp.Body).Decode(&censysResponse)
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 				resp.Body.Close()
@@ -69,11 +69,11 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			resp.Body.Close()
 
 			// Exit the censys enumeration if max pages is reached
-			if currentPage >= response.Metadata.Pages || currentPage >= maxCensysPages {
+			if currentPage >= censysResponse.Metadata.Pages || currentPage >= maxCensysPages {
 				break
 			}
 
-			for _, res := range response.Results {
+			for _, res := range censysResponse.Results {
 				for _, part := range res.Data {
 					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: part}
 				}

--- a/pkg/subscraping/sources/certspotter/certspotter.go
+++ b/pkg/subscraping/sources/certspotter/certspotter.go
@@ -29,7 +29,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.Get(ctx, fmt.Sprintf("https://api.certspotter.com/v1/issuances?domain=%s&include_subdomains=true&expand=dns_names", domain), "", map[string]string{"Authorization": "Bearer " + session.Keys.Certspotter})
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/certspotterold/certspotterold.go
+++ b/pkg/subscraping/sources/certspotterold/certspotterold.go
@@ -19,7 +19,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://certspotter.com/api/v0/certs?domain=%s", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/certspotterold/certspotterold.go
+++ b/pkg/subscraping/sources/certspotterold/certspotterold.go
@@ -16,7 +16,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://certspotter.com/api/v0/certs?domain=%s", domain))
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://certspotter.com/api/v0/certs?domain=%s", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/commoncrawl/commoncrawl.go
+++ b/pkg/subscraping/sources/commoncrawl/commoncrawl.go
@@ -28,7 +28,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		resp, err := session.NormalGetWithContext(ctx, indexURL)
+		resp, err := session.SimpleGet(ctx, indexURL)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)
@@ -81,7 +81,7 @@ func (s *Source) getSubdomains(ctx context.Context, searchURL, domain string, se
 		case <-ctx.Done():
 			return false
 		default:
-			resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("%s?url=*.%s&output=json", searchURL, domain))
+			resp, err := session.SimpleGet(ctx, fmt.Sprintf("%s?url=*.%s&output=json", searchURL, domain))
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 				return false

--- a/pkg/subscraping/sources/commoncrawl/commoncrawl.go
+++ b/pkg/subscraping/sources/commoncrawl/commoncrawl.go
@@ -31,7 +31,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.NormalGetWithContext(ctx, indexURL)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/commoncrawl/commoncrawl.go
+++ b/pkg/subscraping/sources/commoncrawl/commoncrawl.go
@@ -75,7 +75,7 @@ func (s *Source) Name() string {
 	return "commoncrawl"
 }
 
-func (s *Source) getSubdomains(ctx context.Context, searchURL string, domain string, session *subscraping.Session, results chan subscraping.Result) bool {
+func (s *Source) getSubdomains(ctx context.Context, searchURL, domain string, session *subscraping.Session, results chan subscraping.Result) bool {
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/pkg/subscraping/sources/crtsh/crtsh.go
@@ -66,7 +66,7 @@ func (s *Source) getSubdomainsFromHTTP(ctx context.Context, domain string, sessi
 	resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://crt.sh/?q=%%25.%s&output=json", domain))
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-		session.DiscardHttpResponse(resp)
+		session.DiscardHTTPResponse(resp)
 		return false
 	}
 

--- a/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/pkg/subscraping/sources/crtsh/crtsh.go
@@ -20,7 +20,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		found := s.getSubdomainsFromSQL(ctx, domain, session, results)
+		found := s.getSubdomainsFromSQL(domain, results)
 		if found {
 			close(results)
 			return
@@ -32,7 +32,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	return results
 }
 
-func (s *Source) getSubdomainsFromSQL(ctx context.Context, domain string, session *subscraping.Session, results chan subscraping.Result) bool {
+func (s *Source) getSubdomainsFromSQL(domain string, results chan subscraping.Result) bool {
 	db, err := sql.Open("postgres", "host=crt.sh user=guest dbname=certwatch sslmode=disable binary_parameters=yes")
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}

--- a/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/pkg/subscraping/sources/crtsh/crtsh.go
@@ -67,7 +67,7 @@ func (s *Source) getSubdomainsFromSQL(domain string, results chan subscraping.Re
 }
 
 func (s *Source) getSubdomainsFromHTTP(ctx context.Context, domain string, session *subscraping.Session, results chan subscraping.Result) bool {
-	resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://crt.sh/?q=%%25.%s&output=json", domain))
+	resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://crt.sh/?q=%%25.%s&output=json", domain))
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 		session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/pkg/subscraping/sources/crtsh/crtsh.go
@@ -79,7 +79,7 @@ func (s *Source) getSubdomainsFromHTTP(ctx context.Context, domain string, sessi
 	resp.Body.Close()
 
 	// Also replace all newlines
-	src := strings.Replace(string(body), "\\n", " ", -1)
+	src := strings.ReplaceAll(string(body), "\\n", " ",)
 
 	for _, subdomain := range session.Extractor.FindAllString(src, -1) {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}

--- a/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/pkg/subscraping/sources/crtsh/crtsh.go
@@ -79,7 +79,7 @@ func (s *Source) getSubdomainsFromHTTP(ctx context.Context, domain string, sessi
 	resp.Body.Close()
 
 	// Also replace all newlines
-	src := strings.ReplaceAll(string(body), "\\n", " ",)
+	src := strings.ReplaceAll(string(body), "\\n", " ")
 
 	for _, subdomain := range session.Extractor.FindAllString(src, -1) {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}

--- a/pkg/subscraping/sources/dnsdb/dnsdb.go
+++ b/pkg/subscraping/sources/dnsdb/dnsdb.go
@@ -34,7 +34,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			resp, err := session.Get(ctx, fmt.Sprintf("https://api.dnsdb.info/lookup/rrset/name/*.%s?limit=1000000000000", domain), "", headers)
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-				session.DiscardHttpResponse(resp)
+				session.DiscardHTTPResponse(resp)
 				close(results)
 				return
 			}

--- a/pkg/subscraping/sources/dnsdb/dnsdb.go
+++ b/pkg/subscraping/sources/dnsdb/dnsdb.go
@@ -34,7 +34,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			resp, err := session.Get(ctx, fmt.Sprintf("https://api.dnsdb.info/lookup/rrset/name/*.%s?limit=1000000000000", domain), "", headers)
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-				session.DiscardHttpResponse(resp)				
+				session.DiscardHttpResponse(resp)
 				close(results)
 				return
 			}

--- a/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -13,11 +13,14 @@ import (
 	"github.com/projectdiscovery/subfinder/pkg/subscraping"
 )
 
+// CSRFSubMatchLength CSRF regex submatch length
+const CSRFSubMatchLength = 2
+
 var re = regexp.MustCompile("<input type=\"hidden\" name=\"csrfmiddlewaretoken\" value=\"(.*)\">")
 
 // getCSRFToken gets the CSRF Token from the page
 func getCSRFToken(page string) string {
-	if subs := re.FindStringSubmatch(page); len(subs) == 2 {
+	if subs := re.FindStringSubmatch(page); len(subs) == CSRFSubMatchLength {
 		return strings.TrimSpace(subs[1])
 	}
 	return ""

--- a/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -27,7 +27,7 @@ func getCSRFToken(page string) string {
 }
 
 // postForm posts a form for a domain and returns the response
-func postForm(token, domain string) (string, error) {
+func postForm(ctx context.Context, token, domain string) (string, error) {
 	dial := net.Dialer{}
 	client := &http.Client{
 		Transport: &http.Transport{
@@ -40,7 +40,7 @@ func postForm(token, domain string) (string, error) {
 		"targetip":            {domain},
 	}
 
-	req, err := http.NewRequest("POST", "https://dnsdumpster.com/", strings.NewReader(params.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://dnsdumpster.com/", strings.NewReader(params.Encode()))
 	if err != nil {
 		return "", err
 	}
@@ -94,7 +94,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp.Body.Close()
 		csrfToken := getCSRFToken(string(body))
 
-		data, err := postForm(csrfToken, domain)
+		data, err := postForm(ctx, csrfToken, domain)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			close(results)

--- a/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -79,7 +79,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.NormalGetWithContext(ctx, "https://dnsdumpster.com/")
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -3,12 +3,9 @@ package dnsdumpster
 import (
 	"context"
 	"io/ioutil"
-	"net"
-	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/projectdiscovery/subfinder/pkg/subscraping"
 )
@@ -27,41 +24,38 @@ func getCSRFToken(page string) string {
 }
 
 // postForm posts a form for a domain and returns the response
-func postForm(ctx context.Context, token, domain string) (string, error) {
-	dial := net.Dialer{}
-	client := &http.Client{
-		Transport: &http.Transport{
-			DialContext:         dial.DialContext,
-			TLSHandshakeTimeout: 10 * time.Second,
-		},
-	}
+func postForm(ctx context.Context, session *subscraping.Session, token, domain string) (string, error) {
+	// dial := net.Dialer{}
+	// client := &http.Client{
+	// 	Transport: &http.Transport{
+	// 		DialContext:         dial.DialContext,
+	// 		TLSHandshakeTimeout: 10 * time.Second,
+	// 	},
+	// }
 	params := url.Values{
 		"csrfmiddlewaretoken": {token},
 		"targetip":            {domain},
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", "https://dnsdumpster.com/", strings.NewReader(params.Encode()))
+	resp, err := session.HTTPRequest(
+		ctx,
+		"POST",
+		"https://dnsdumpster.com/",
+		"csrftoken=" + token +"; Domain=dnsdumpster.com",
+		map[string]string{
+			"Content-Type": "application/x-www-form-urlencoded",
+			"Referer": "https://dnsdumpster.com",
+			"X-CSRF-Token": token,
+		},
+		strings.NewReader(params.Encode()),
+		subscraping.BasicAuth{},
+	)
+
 	if err != nil {
+		session.DiscardHTTPResponse(resp)
 		return "", err
 	}
 
-	// The CSRF token needs to be sent as a cookie
-	cookie := &http.Cookie{
-		Name:   "csrftoken",
-		Domain: "dnsdumpster.com",
-		Value:  token,
-	}
-	req.AddCookie(cookie)
-
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36")
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Referer", "https://dnsdumpster.com")
-	req.Header.Set("X-CSRF-Token", token)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
 	// Now, grab the entire page
 	in, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
@@ -76,7 +70,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		resp, err := session.NormalGetWithContext(ctx, "https://dnsdumpster.com/")
+		resp, err := session.SimpleGet(ctx, "https://dnsdumpster.com/")
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)
@@ -94,7 +88,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp.Body.Close()
 		csrfToken := getCSRFToken(string(body))
 
-		data, err := postForm(ctx, csrfToken, domain)
+		data, err := postForm(ctx, session, csrfToken, domain)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			close(results)

--- a/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -25,13 +25,6 @@ func getCSRFToken(page string) string {
 
 // postForm posts a form for a domain and returns the response
 func postForm(ctx context.Context, session *subscraping.Session, token, domain string) (string, error) {
-	// dial := net.Dialer{}
-	// client := &http.Client{
-	// 	Transport: &http.Transport{
-	// 		DialContext:         dial.DialContext,
-	// 		TLSHandshakeTimeout: 10 * time.Second,
-	// 	},
-	// }
 	params := url.Values{
 		"csrfmiddlewaretoken": {token},
 		"targetip":            {domain},

--- a/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -34,10 +34,10 @@ func postForm(ctx context.Context, session *subscraping.Session, token, domain s
 		ctx,
 		"POST",
 		"https://dnsdumpster.com/",
-		"csrftoken=" + token +"; Domain=dnsdumpster.com",
+		"csrftoken="+token+"; Domain=dnsdumpster.com",
 		map[string]string{
 			"Content-Type": "application/x-www-form-urlencoded",
-			"Referer": "https://dnsdumpster.com",
+			"Referer":      "https://dnsdumpster.com",
 			"X-CSRF-Token": token,
 		},
 		strings.NewReader(params.Encode()),

--- a/pkg/subscraping/sources/entrust/entrust.go
+++ b/pkg/subscraping/sources/entrust/entrust.go
@@ -20,7 +20,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://ctsearch.entrust.com/api/v1/certificates?fields=issuerCN,subjectO,issuerDN,issuerO,subjectDN,signAlg,san,publicKeyType,publicKeySize,validFrom,validTo,sn,ev,logEntries.logName,subjectCNReversed,cert&domain=%s&includeExpired=true&exactMatch=false&limit=5000", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/entrust/entrust.go
+++ b/pkg/subscraping/sources/entrust/entrust.go
@@ -17,7 +17,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://ctsearch.entrust.com/api/v1/certificates?fields=issuerCN,subjectO,issuerDN,issuerO,subjectDN,signAlg,san,publicKeyType,publicKeySize,validFrom,validTo,sn,ev,logEntries.logName,subjectCNReversed,cert&domain=%s&includeExpired=true&exactMatch=false&limit=5000", domain))
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://ctsearch.entrust.com/api/v1/certificates?fields=issuerCN,subjectO,issuerDN,issuerO,subjectDN,signAlg,san,publicKeyType,publicKeySize,validFrom,validTo,sn,ev,logEntries.logName,subjectCNReversed,cert&domain=%s&includeExpired=true&exactMatch=false&limit=5000", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/github/github.go
+++ b/pkg/subscraping/sources/github/github.go
@@ -175,8 +175,8 @@ func normalizeContent(content string) string {
 func unique(arr []string) []string {
 	occurred := map[string]bool{}
 	result := []string{}
-	for e := range arr {
-		if occurred[arr[e]] != true {
+	for e := range arr {		
+		if !occurred[arr[e]] {
 			occurred[arr[e]] = true
 			result = append(result, arr[e])
 		}

--- a/pkg/subscraping/sources/github/github.go
+++ b/pkg/subscraping/sources/github/github.go
@@ -175,7 +175,7 @@ func normalizeContent(content string) string {
 func unique(arr []string) []string {
 	occurred := map[string]bool{}
 	result := []string{}
-	for e := range arr {		
+	for e := range arr {
 		if !occurred[arr[e]] {
 			occurred[arr[e]] = true
 			result = append(result, arr[e])
@@ -185,9 +185,9 @@ func unique(arr []string) []string {
 }
 
 // Find matches by regular expression in any content
-func matches(regexp *regexp.Regexp, content string) []string {
+func matches(regex *regexp.Regexp, content string) []string {
 	var matches []string
-	match := regexp.FindAllString(content, -1)
+	match := regex.FindAllString(content, -1)
 	if len(match) > 0 {
 		matches = unique(match)
 	}

--- a/pkg/subscraping/sources/github/github.go
+++ b/pkg/subscraping/sources/github/github.go
@@ -77,10 +77,7 @@ func (s *Source) enumerate(ctx context.Context, searchURL string, domainRegexp *
 		}
 	}
 
-	headers := map[string]string{
-		"Accept":        "application/vnd.github.v3.text-match+json",
-		"Authorization": "token " + token.Hash,
-	}
+	headers := map[string]string{"Accept": "application/vnd.github.v3.text-match+json", "Authorization": "token " + token.Hash}
 
 	// Initial request to GitHub search
 	resp, err := session.Get(ctx, searchURL, "", headers)

--- a/pkg/subscraping/sources/github/github.go
+++ b/pkg/subscraping/sources/github/github.go
@@ -102,7 +102,7 @@ func (s *Source) enumerate(ctx context.Context, searchURL string, domainRegexp *
 
 				data := response{}
 
-				// Marshall json reponse
+				// Marshall json response
 				err = jsoniter.NewDecoder(resp.Body).Decode(&data)
 				resp.Body.Close()
 				if err != nil {
@@ -172,11 +172,11 @@ func normalizeContent(content string) string {
 
 // Remove duplicates from string array
 func unique(arr []string) []string {
-    occured := map[string]bool{}
+    occurred := map[string]bool{}
     result := []string{}
     for e := range arr {
-        if occured[arr[e]] != true {
-            occured[arr[e]] = true
+        if occurred[arr[e]] != true {
+            occurred[arr[e]] = true
             result = append(result, arr[e])
         }
     }

--- a/pkg/subscraping/sources/github/github.go
+++ b/pkg/subscraping/sources/github/github.go
@@ -165,8 +165,8 @@ func (s *Source) enumerate(ctx context.Context, searchURL string, domainRegexp *
 // Normalize content before matching, query unescape, remove tabs and new line chars
 func normalizeContent(content string) string {
 	normalizedContent, _ := url.QueryUnescape(content)
-	normalizedContent = strings.Replace(normalizedContent, "\\t", "", -1)
-	normalizedContent = strings.Replace(normalizedContent, "\\n", "", -1)
+	normalizedContent = strings.ReplaceAll(normalizedContent, "\\t", "")
+	normalizedContent = strings.ReplaceAll(normalizedContent, "\\n", "")
 	return normalizedContent
 }
 
@@ -195,13 +195,13 @@ func matches(regexp *regexp.Regexp, content string) []string {
 
 // Raw URL to get the files code and match for subdomains
 func rawUrl(htmlUrl string) string {
-	domain := strings.Replace(htmlUrl, "https://github.com/", "https://raw.githubusercontent.com/", -1)
-	return strings.Replace(domain, "/blob/", "/", -1)
+	domain := strings.ReplaceAll(htmlUrl, "https://github.com/", "https://raw.githubusercontent.com/")
+	return strings.ReplaceAll(domain, "/blob/", "/")
 }
 
 // Domain regular expression to match subdomains in github files code
 func (s *Source) DomainRegexp(domain string) *regexp.Regexp {
-	rdomain := strings.Replace(domain, ".", "\\.", -1)
+	rdomain := strings.ReplaceAll(domain, ".", "\\.")
 	return regexp.MustCompile("(\\w+[.])*" + rdomain)
 }
 

--- a/pkg/subscraping/sources/github/github.go
+++ b/pkg/subscraping/sources/github/github.go
@@ -149,7 +149,7 @@ func (s *Source) enumerate(ctx context.Context, searchURL string, domainRegexp *
 			}
 		}
 
-		// Proccess the next link recursively
+		// Process the next link recursively
 		for _, link := range linksHeader {
 			if link.Rel == "next" {
 				nextURL, err := url.QueryUnescape(link.URL)

--- a/pkg/subscraping/sources/github/github.go
+++ b/pkg/subscraping/sources/github/github.go
@@ -112,7 +112,7 @@ func (s *Source) enumerate(ctx context.Context, searchURL string, domainRegexp *
 
 		// Response items iteration
 		for _, item := range data.Items {
-			resp, err := session.NormalGetWithContext(ctx, rawURL(item.HTMLURL))
+			resp, err := session.SimpleGet(ctx, rawURL(item.HTMLURL))
 			if err != nil {
 				if resp != nil && resp.StatusCode != http.StatusNotFound {
 					session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/github/tokenmanager.go
+++ b/pkg/subscraping/sources/github/tokenmanager.go
@@ -41,7 +41,7 @@ func (r *Tokens) setCurrentTokenExceeded(retryAfter int64) {
 }
 
 // Get returns a new token from the token pool
-func (r *Tokens) Get() (*Token) {
+func (r *Tokens) Get() *Token {
 	resetExceededTokens(r)
 
 	if r.current >= len(r.pool) {

--- a/pkg/subscraping/sources/github/tokenmanager.go
+++ b/pkg/subscraping/sources/github/tokenmanager.go
@@ -2,21 +2,25 @@ package github
 
 import "time"
 
-type token struct {
+// Token struct
+type Token struct {
 	Hash         string
 	RetryAfter   int64
 	ExceededTime time.Time
 }
 
+// Tokens is the internal struct to manage the current token
+// and the pool
 type Tokens struct {
 	current int
-	pool    []token
+	pool    []Token
 }
 
+// NewTokenManager initialize the tokens pool
 func NewTokenManager(keys []string) *Tokens {
-	pool := []token{}
+	pool := []Token{}
 	for _, key := range keys {
-		t := token{Hash: key, ExceededTime: time.Time{}, RetryAfter: 0}
+		t := Token{Hash: key, ExceededTime: time.Time{}, RetryAfter: 0}
 		pool = append(pool, t)
 	}
 
@@ -36,14 +40,15 @@ func (r *Tokens) setCurrentTokenExceeded(retryAfter int64) {
 	}
 }
 
-func (r *Tokens) Get() token {
+// Get returns a new token from the token pool
+func (r *Tokens) Get() (*Token) {
 	resetExceededTokens(r)
 
 	if r.current >= len(r.pool) {
 		r.current %= len(r.pool)
 	}
 
-	result := r.pool[r.current]
+	result := &r.pool[r.current]
 	r.current++
 
 	return result

--- a/pkg/subscraping/sources/github/tokenmanager.go
+++ b/pkg/subscraping/sources/github/tokenmanager.go
@@ -28,7 +28,7 @@ func NewTokenManager(keys []string) *Tokens {
 
 func (r *Tokens) setCurrentTokenExceeded(retryAfter int64) {
 	if r.current >= len(r.pool) {
-		r.current = r.current % len(r.pool)
+		r.current %= len(r.pool)
 	}
 	if r.pool[r.current].RetryAfter == 0 {
 		r.pool[r.current].ExceededTime = time.Now()
@@ -40,7 +40,7 @@ func (r *Tokens) Get() token {
 	resetExceededTokens(r)
 
 	if r.current >= len(r.pool) {
-		r.current = r.current % len(r.pool)
+		r.current %= len(r.pool)
 	}
 
 	result := r.pool[r.current]

--- a/pkg/subscraping/sources/hackertarget/hackertarget.go
+++ b/pkg/subscraping/sources/hackertarget/hackertarget.go
@@ -19,7 +19,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("http://api.hackertarget.com/hostsearch/?q=%s", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/hackertarget/hackertarget.go
+++ b/pkg/subscraping/sources/hackertarget/hackertarget.go
@@ -16,7 +16,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("http://api.hackertarget.com/hostsearch/?q=%s", domain))
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("http://api.hackertarget.com/hostsearch/?q=%s", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/intelx/intelx.go
+++ b/pkg/subscraping/sources/intelx/intelx.go
@@ -92,7 +92,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 				return
 			}
-			body, err = ioutil.ReadAll(resp.Body)
+			_, err = ioutil.ReadAll(resp.Body)
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 				return

--- a/pkg/subscraping/sources/intelx/intelx.go
+++ b/pkg/subscraping/sources/intelx/intelx.go
@@ -13,7 +13,7 @@ import (
 )
 
 type searchResponseType struct {
-	Id     string `json:"id"`
+	ID     string `json:"id"`
 	Status int    `json:"status"`
 }
 
@@ -66,7 +66,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := http.Post(searchURL, "application/json", bytes.NewBuffer(body))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			return
 		}
 
@@ -78,7 +78,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
-		resultsURL := fmt.Sprintf("https://%s/phonebook/search/result?k=%s&id=%s&limit=10000", session.Keys.IntelXHost, session.Keys.IntelXKey, response.Id)
+		resultsURL := fmt.Sprintf("https://%s/phonebook/search/result?k=%s&id=%s&limit=10000", session.Keys.IntelXHost, session.Keys.IntelXKey, response.ID)
 		status := 0
 		for status == 0 || status == 3 {
 			resp, err = session.Get(ctx, resultsURL, "", nil)

--- a/pkg/subscraping/sources/intelx/intelx.go
+++ b/pkg/subscraping/sources/intelx/intelx.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/projectdiscovery/subfinder/pkg/subscraping"
@@ -63,7 +62,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
-		resp, err := http.Post(searchURL, "application/json", bytes.NewBuffer(body)) //nolint:noctx // needs refactor
+		resp, err := session.SimplePost(ctx, searchURL, "application/json", bytes.NewBuffer(body))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/intelx/intelx.go
+++ b/pkg/subscraping/sources/intelx/intelx.go
@@ -63,7 +63,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
-		resp, err := http.Post(searchURL, "application/json", bytes.NewBuffer(body))
+		resp, err := http.Post(searchURL, "application/json", bytes.NewBuffer(body)) //nolint:noctx // needs refactor
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)
@@ -77,6 +77,8 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			close(results)
 			return
 		}
+
+		resp.Body.Close()
 
 		resultsURL := fmt.Sprintf("https://%s/phonebook/search/result?k=%s&id=%s&limit=10000", session.Keys.IntelXHost, session.Keys.IntelXKey, response.ID)
 		status := 0

--- a/pkg/subscraping/sources/ipv4info/ipv4info.go
+++ b/pkg/subscraping/sources/ipv4info/ipv4info.go
@@ -20,7 +20,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.NormalGetWithContext(ctx, "http://ipv4info.com/search/"+domain)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/ipv4info/ipv4info.go
+++ b/pkg/subscraping/sources/ipv4info/ipv4info.go
@@ -38,7 +38,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		regxTokens := regexp.MustCompile("/ip-address/(.*)/" + domain)
 		matchTokens := regxTokens.FindAllString(src, -1)
 
-		if len(matchTokens) <= 0 {
+		if len(matchTokens) == 0 {
 			close(results)
 			return
 		}
@@ -63,7 +63,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 		regxTokens = regexp.MustCompile("/dns/(.*?)/" + domain)
 		matchTokens = regxTokens.FindAllString(src, -1)
-		if len(matchTokens) <= 0 {
+		if len(matchTokens) == 0 {
 			close(results)
 			return
 		}
@@ -88,7 +88,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 		regxTokens = regexp.MustCompile("/subdomains/(.*?)/" + domain)
 		matchTokens = regxTokens.FindAllString(src, -1)
-		if len(matchTokens) <= 0 {
+		if len(matchTokens) == 0 {
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/ipv4info/ipv4info.go
+++ b/pkg/subscraping/sources/ipv4info/ipv4info.go
@@ -17,7 +17,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		resp, err := session.NormalGetWithContext(ctx, "http://ipv4info.com/search/"+domain)
+		resp, err := session.SimpleGet(ctx, "http://ipv4info.com/search/"+domain)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)
@@ -44,7 +44,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		}
 		token := matchTokens[0]
 
-		resp, err = session.NormalGetWithContext(ctx, "http://ipv4info.com"+token)
+		resp, err = session.SimpleGet(ctx, "http://ipv4info.com"+token)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			close(results)
@@ -69,7 +69,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		}
 		token = matchTokens[0]
 
-		resp, err = session.NormalGetWithContext(ctx, "http://ipv4info.com"+token)
+		resp, err = session.SimpleGet(ctx, "http://ipv4info.com"+token)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			close(results)
@@ -94,7 +94,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		}
 		token = matchTokens[0]
 
-		resp, err = session.NormalGetWithContext(ctx, "http://ipv4info.com"+token)
+		resp, err = session.SimpleGet(ctx, "http://ipv4info.com"+token)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			close(results)
@@ -146,7 +146,7 @@ func (s *Source) getSubdomains(ctx context.Context, domain string, nextPage *int
 			}
 			token := matchTokens[0]
 
-			resp, err := session.NormalGetWithContext(ctx, "http://ipv4info.com"+token)
+			resp, err := session.SimpleGet(ctx, "http://ipv4info.com"+token)
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 				return false

--- a/pkg/subscraping/sources/rapiddns/rapiddns.go
+++ b/pkg/subscraping/sources/rapiddns/rapiddns.go
@@ -20,7 +20,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.NormalGetWithContext(ctx, "https://rapiddns.io/subdomain/"+domain+"?full=1")
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			return
 		}
 

--- a/pkg/subscraping/sources/rapiddns/rapiddns.go
+++ b/pkg/subscraping/sources/rapiddns/rapiddns.go
@@ -17,7 +17,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 	go func() {
 		defer close(results)
-		resp, err := session.NormalGetWithContext(ctx, "https://rapiddns.io/subdomain/"+domain+"?full=1")
+		resp, err := session.SimpleGet(ctx, "https://rapiddns.io/subdomain/"+domain+"?full=1")
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/securitytrails/securitytrails.go
+++ b/pkg/subscraping/sources/securitytrails/securitytrails.go
@@ -34,8 +34,8 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
-		response := response{}
-		err = jsoniter.NewDecoder(resp.Body).Decode(&response)
+		securityTrailsResponse := response{}
+		err = jsoniter.NewDecoder(resp.Body).Decode(&securityTrailsResponse)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			resp.Body.Close()
@@ -44,7 +44,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		}
 		resp.Body.Close()
 
-		for _, subdomain := range response.Subdomains {
+		for _, subdomain := range securityTrailsResponse.Subdomains {
 			if strings.HasSuffix(subdomain, ".") {
 				subdomain += domain
 			} else {

--- a/pkg/subscraping/sources/securitytrails/securitytrails.go
+++ b/pkg/subscraping/sources/securitytrails/securitytrails.go
@@ -46,7 +46,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 		for _, subdomain := range response.Subdomains {
 			if strings.HasSuffix(subdomain, ".") {
-				subdomain = subdomain + domain
+				subdomain += domain
 			} else {
 				subdomain = subdomain + "." + domain
 			}

--- a/pkg/subscraping/sources/securitytrails/securitytrails.go
+++ b/pkg/subscraping/sources/securitytrails/securitytrails.go
@@ -29,7 +29,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.Get(ctx, fmt.Sprintf("https://api.securitytrails.com/v1/domain/%s/subdomains", domain), "", map[string]string{"APIKEY": session.Keys.Securitytrails})
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/shodan/shodan.go
+++ b/pkg/subscraping/sources/shodan/shodan.go
@@ -32,7 +32,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		}
 
 		for currentPage := 0; currentPage <= 10; currentPage++ {
-			resp, err := session.NormalGetWithContext(ctx, "https://api.shodan.io/shodan/host/search?query=hostname:"+domain+"&page="+strconv.Itoa(currentPage)+"&key="+session.Keys.Shodan)
+			resp, err := session.SimpleGet(ctx, "https://api.shodan.io/shodan/host/search?query=hostname:"+domain+"&page="+strconv.Itoa(currentPage)+"&key="+session.Keys.Shodan)
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 				session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/shodan/shodan.go
+++ b/pkg/subscraping/sources/shodan/shodan.go
@@ -35,7 +35,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			resp, err := session.NormalGetWithContext(ctx, "https://api.shodan.io/shodan/host/search?query=hostname:"+domain+"&page="+strconv.Itoa(currentPage)+"&key="+session.Keys.Shodan)
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-				session.DiscardHttpResponse(resp)
+				session.DiscardHTTPResponse(resp)
 				close(results)
 				return
 			}

--- a/pkg/subscraping/sources/sitedossier/sitedossier.go
+++ b/pkg/subscraping/sources/sitedossier/sitedossier.go
@@ -54,7 +54,10 @@ func (a *agent) enumerate(ctx context.Context, baseURL string) error {
 			time.Sleep(time.Duration((3 + rand.Intn(SleepRandIntn))) * time.Second)
 
 			if len(match1) > 0 {
-				a.enumerate(ctx, "http://www.sitedossier.com"+match1[1])
+				err := a.enumerate(ctx, "http://www.sitedossier.com"+match1[1])
+				if err != nil {
+					return err
+				}
 			}
 			return nil
 		}

--- a/pkg/subscraping/sources/sitedossier/sitedossier.go
+++ b/pkg/subscraping/sources/sitedossier/sitedossier.go
@@ -15,7 +15,7 @@ import (
 // to sleep before find the next match
 const SleepRandIntn = 5
 
-var reNext = regexp.MustCompile("<a href=\"([A-Za-z0-9\\/.]+)\"><b>")
+var reNext = regexp.MustCompile(`<a href="([A-Za-z0-9/.]+)"><b>`)
 
 type agent struct {
 	results chan subscraping.Result

--- a/pkg/subscraping/sources/sitedossier/sitedossier.go
+++ b/pkg/subscraping/sources/sitedossier/sitedossier.go
@@ -28,7 +28,7 @@ func (a *agent) enumerate(ctx context.Context, baseURL string) error {
 		case <-ctx.Done():
 			return nil
 		default:
-			resp, err := a.session.NormalGetWithContext(ctx, baseURL)
+			resp, err := a.session.SimpleGet(ctx, baseURL)
 			if err != nil {
 				a.results <- subscraping.Result{Source: "sitedossier", Type: subscraping.Error, Error: err}
 				a.session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/sitedossier/sitedossier.go
+++ b/pkg/subscraping/sources/sitedossier/sitedossier.go
@@ -31,7 +31,7 @@ func (a *agent) enumerate(ctx context.Context, baseURL string) error {
 			resp, err := a.session.NormalGetWithContext(ctx, baseURL)
 			if err != nil {
 				a.results <- subscraping.Result{Source: "sitedossier", Type: subscraping.Error, Error: err}
-				a.session.DiscardHttpResponse(resp)
+				a.session.DiscardHTTPResponse(resp)
 				close(a.results)
 				return err
 			}

--- a/pkg/subscraping/sources/sitedossier/sitedossier.go
+++ b/pkg/subscraping/sources/sitedossier/sitedossier.go
@@ -11,6 +11,10 @@ import (
 	"github.com/projectdiscovery/subfinder/pkg/subscraping"
 )
 
+// SleepRandIntn is the integer value to get the pseudo-random number
+// to sleep before find the next match
+const SleepRandIntn = 5
+
 var reNext = regexp.MustCompile("<a href=\"([A-Za-z0-9\\/.]+)\"><b>")
 
 type agent struct {
@@ -47,7 +51,7 @@ func (a *agent) enumerate(ctx context.Context, baseURL string) error {
 			}
 
 			match1 := reNext.FindStringSubmatch(src)
-			time.Sleep(time.Duration((3 + rand.Intn(5))) * time.Second)
+			time.Sleep(time.Duration((3 + rand.Intn(SleepRandIntn))) * time.Second)
 
 			if len(match1) > 0 {
 				a.enumerate(ctx, "http://www.sitedossier.com"+match1[1])

--- a/pkg/subscraping/sources/spyse/spyse.go
+++ b/pkg/subscraping/sources/spyse/spyse.go
@@ -15,7 +15,7 @@ type resultObject struct {
 
 type dataObject struct {
 	Items       []resultObject `json:"items"`
-	Total_Count int            `json:"total_count"`
+	TotalCount int            `json:"total_count"`
 }
 
 type errorObject struct {
@@ -45,7 +45,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			resp, err := session.Get(ctx, fmt.Sprintf("https://api.spyse.com/v3/data/domain/subdomain?domain=%s&limit=100&offset=%s", domain, strconv.Itoa(offSet)), "", map[string]string{"Authorization": "Bearer " + session.Keys.Spyse})
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-				session.DiscardHttpResponse(resp)
+				session.DiscardHTTPResponse(resp)
 				close(results)
 				return
 			}
@@ -62,12 +62,12 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			}
 			resp.Body.Close()
 
-			if response.Data.Total_Count == 0 {
+			if response.Data.TotalCount == 0 {
 				close(results)
 				return
 			}
 
-			maxCount = response.Data.Total_Count
+			maxCount = response.Data.TotalCount
 
 			for _, hostname := range response.Data.Items {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: hostname.Name}

--- a/pkg/subscraping/sources/spyse/spyse.go
+++ b/pkg/subscraping/sources/spyse/spyse.go
@@ -2,34 +2,31 @@ package spyse
 
 import (
 	"context"
-	"strconv"
 	"fmt"
+	"strconv"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/projectdiscovery/subfinder/pkg/subscraping"
 )
-
 
 type resultObject struct {
 	Name string `json:"name"`
 }
 
 type dataObject struct {
-	Items []resultObject `json:"items"`
-	Total_Count int `json:"total_count"`
+	Items       []resultObject `json:"items"`
+	Total_Count int            `json:"total_count"`
 }
 
 type errorObject struct {
-	Code string `json:"code"`
+	Code    string `json:"code"`
 	Message string `json:"message"`
 }
 
-
 type spyseResult struct {
-	Data dataObject `json:"data"`
+	Data  dataObject    `json:"data"`
 	Error []errorObject `json:"error"`
 }
-
 
 type Source struct{}
 
@@ -42,7 +39,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
-		maxCount := 100;
+		maxCount := 100
 
 		for offSet := 0; offSet <= maxCount; offSet += 100 {
 			resp, err := session.Get(ctx, fmt.Sprintf("https://api.spyse.com/v3/data/domain/subdomain?domain=%s&limit=100&offset=%s", domain, strconv.Itoa(offSet)), "", map[string]string{"Authorization": "Bearer " + session.Keys.Spyse})
@@ -53,8 +50,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				return
 			}
 
-
-			var response spyseResult;
+			var response spyseResult
 
 			err = jsoniter.NewDecoder(resp.Body).Decode(&response)
 
@@ -71,7 +67,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				return
 			}
 
-			maxCount = response.Data.Total_Count;
+			maxCount = response.Data.Total_Count
 
 			for _, hostname := range response.Data.Items {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: hostname.Name}
@@ -82,7 +78,6 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 	return results
 }
-
 
 // Name returns the name of the source
 func (s *Source) Name() string {

--- a/pkg/subscraping/sources/spyse/spyse.go
+++ b/pkg/subscraping/sources/spyse/spyse.go
@@ -14,7 +14,7 @@ type resultObject struct {
 }
 
 type dataObject struct {
-	Items       []resultObject `json:"items"`
+	Items      []resultObject `json:"items"`
 	TotalCount int            `json:"total_count"`
 }
 

--- a/pkg/subscraping/sources/spyse/spyse.go
+++ b/pkg/subscraping/sources/spyse/spyse.go
@@ -28,8 +28,10 @@ type spyseResult struct {
 	Error []errorObject `json:"error"`
 }
 
+// Source is the passive scraping agent
 type Source struct{}
 
+// Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
 

--- a/pkg/subscraping/sources/sublist3r/subllist3r.go
+++ b/pkg/subscraping/sources/sublist3r/subllist3r.go
@@ -19,7 +19,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://api.sublist3r.com/search.php?domain=%s", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/sublist3r/subllist3r.go
+++ b/pkg/subscraping/sources/sublist3r/subllist3r.go
@@ -16,7 +16,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://api.sublist3r.com/search.php?domain=%s", domain))
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://api.sublist3r.com/search.php?domain=%s", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/threatcrowd/threatcrowd.go
+++ b/pkg/subscraping/sources/threatcrowd/threatcrowd.go
@@ -19,7 +19,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://www.threatcrowd.org/searchApi/v2/domain/report/?domain=%s", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/threatcrowd/threatcrowd.go
+++ b/pkg/subscraping/sources/threatcrowd/threatcrowd.go
@@ -16,7 +16,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://www.threatcrowd.org/searchApi/v2/domain/report/?domain=%s", domain))
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://www.threatcrowd.org/searchApi/v2/domain/report/?domain=%s", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/threatminer/threatminer.go
+++ b/pkg/subscraping/sources/threatminer/threatminer.go
@@ -19,7 +19,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://api.threatminer.org/v2/domain.php?q=%s&rt=5", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/threatminer/threatminer.go
+++ b/pkg/subscraping/sources/threatminer/threatminer.go
@@ -16,7 +16,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://api.threatminer.org/v2/domain.php?q=%s&rt=5", domain))
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://api.threatminer.org/v2/domain.php?q=%s&rt=5", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/virustotal/virustotal.go
+++ b/pkg/subscraping/sources/virustotal/virustotal.go
@@ -28,7 +28,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://www.virustotal.com/vtapi/v2/domain/report?apikey=%s&domain=%s", session.Keys.Virustotal, domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(resp)
+			session.DiscardHTTPResponse(resp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/virustotal/virustotal.go
+++ b/pkg/subscraping/sources/virustotal/virustotal.go
@@ -25,7 +25,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
-		resp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("https://www.virustotal.com/vtapi/v2/domain/report?apikey=%s&domain=%s", session.Keys.Virustotal, domain))
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://www.virustotal.com/vtapi/v2/domain/report?apikey=%s&domain=%s", session.Keys.Virustotal, domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/waybackarchive/waybackarchive.go
+++ b/pkg/subscraping/sources/waybackarchive/waybackarchive.go
@@ -20,7 +20,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		pagesResp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("http://web.archive.org/cdx/search/cdx?url=*.%s/*&output=json&fl=original&collapse=urlkey", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHttpResponse(pagesResp)
+			session.DiscardHTTPResponse(pagesResp)
 			close(results)
 			return
 		}

--- a/pkg/subscraping/sources/waybackarchive/waybackarchive.go
+++ b/pkg/subscraping/sources/waybackarchive/waybackarchive.go
@@ -17,7 +17,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		pagesResp, err := session.NormalGetWithContext(ctx, fmt.Sprintf("http://web.archive.org/cdx/search/cdx?url=*.%s/*&output=json&fl=original&collapse=urlkey", domain))
+		pagesResp, err := session.SimpleGet(ctx, fmt.Sprintf("http://web.archive.org/cdx/search/cdx?url=*.%s/*&output=json&fl=original&collapse=urlkey", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(pagesResp)

--- a/pkg/subscraping/sources/zoomeye/zoomeye.go
+++ b/pkg/subscraping/sources/zoomeye/zoomeye.go
@@ -41,7 +41,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			close(results)
 			return
 		}
-		jwt, err := doLogin(session)
+		jwt, err := doLogin(ctx, session)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			close(results)
@@ -96,7 +96,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 }
 
 // doLogin performs authentication on the ZoomEye API
-func doLogin(session *subscraping.Session) (string, error) {
+func doLogin(ctx context.Context, session *subscraping.Session) (string, error) {
 	creds := &zoomAuth{
 		User: session.Keys.ZoomEyeUsername,
 		Pass: session.Keys.ZoomEyePassword,
@@ -105,7 +105,7 @@ func doLogin(session *subscraping.Session) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	req, err := http.NewRequest("POST", "https://api.zoomeye.org/user/login", bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.zoomeye.org/user/login", bytes.NewBuffer(body))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/subscraping/sources/zoomeye/zoomeye.go
+++ b/pkg/subscraping/sources/zoomeye/zoomeye.go
@@ -117,7 +117,7 @@ func doLogin(session *subscraping.Session) (string, error) {
 		return "", err
 	}
 	// if not 200, bad credentials
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		io.Copy(ioutil.Discard, resp.Body)
 		resp.Body.Close()
 		return "", fmt.Errorf("login failed, non-200 response from zoomeye")

--- a/pkg/subscraping/sources/zoomeye/zoomeye.go
+++ b/pkg/subscraping/sources/zoomeye/zoomeye.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/projectdiscovery/subfinder/pkg/subscraping"
@@ -118,8 +116,7 @@ func doLogin(session *subscraping.Session) (string, error) {
 	}
 	// if not 200, bad credentials
 	if resp.StatusCode != http.StatusOK {
-		io.Copy(ioutil.Discard, resp.Body)
-		resp.Body.Close()
+		session.DiscardHTTPResponse(resp)
 		return "", fmt.Errorf("login failed, non-200 response from zoomeye")
 	}
 

--- a/pkg/subscraping/sources/zoomeye/zoomeye.go
+++ b/pkg/subscraping/sources/zoomeye/zoomeye.go
@@ -67,7 +67,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			if err != nil {
 				if !isForbidden && currentPage == 0 {
 					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-					session.DiscardHttpResponse(resp)
+					session.DiscardHTTPResponse(resp)
 				}
 				close(results)
 				return

--- a/pkg/subscraping/sources/zoomeye/zoomeye.go
+++ b/pkg/subscraping/sources/zoomeye/zoomeye.go
@@ -105,19 +105,10 @@ func doLogin(ctx context.Context, session *subscraping.Session) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.zoomeye.org/user/login", bytes.NewBuffer(body))
+	resp, err := session.SimplePost(ctx, "https://api.zoomeye.org/user/login", "application/json", bytes.NewBuffer(body))
 	if err != nil {
-		return "", err
-	}
-	req.Header.Add("Content-Type", "application/json")
-	resp, err := session.Client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	// if not 200, bad credentials
-	if resp.StatusCode != http.StatusOK {
 		session.DiscardHTTPResponse(resp)
-		return "", fmt.Errorf("login failed, non-200 response from zoomeye")
+		return "", err
 	}
 
 	defer resp.Body.Close()

--- a/pkg/subscraping/types.go
+++ b/pkg/subscraping/types.go
@@ -6,6 +6,12 @@ import (
 	"regexp"
 )
 
+// BasicAuth request's Authorization header
+type BasicAuth struct {
+	Username string
+	Password string
+}
+
 // Source is an interface inherited by each passive source
 type Source interface {
 	// Run takes a domain as argument and a session object

--- a/pkg/subscraping/types.go
+++ b/pkg/subscraping/types.go
@@ -29,24 +29,24 @@ type Session struct {
 
 // Keys contains the current API Keys we have in store
 type Keys struct {
-	Binaryedge           string `json:"binaryedge"`
-	CensysToken          string `json:"censysUsername"`
-	CensysSecret         string `json:"censysPassword"`
-	Certspotter          string `json:"certspotter"`
-	Chaos                string `json:"chaos"`
-	DNSDB                string `json:"dnsdb"`
+	Binaryedge           string   `json:"binaryedge"`
+	CensysToken          string   `json:"censysUsername"`
+	CensysSecret         string   `json:"censysPassword"`
+	Certspotter          string   `json:"certspotter"`
+	Chaos                string   `json:"chaos"`
+	DNSDB                string   `json:"dnsdb"`
 	GitHub               []string `json:"github"`
-	IntelXHost           string `json:"intelXHost"`
-	IntelXKey            string `json:"intelXKey"`
-	PassiveTotalUsername string `json:"passivetotal_username"`
-	PassiveTotalPassword string `json:"passivetotal_password"`
-	Securitytrails       string `json:"securitytrails"`
-	Shodan               string `json:"shodan"`
-	Spyse                string `json:"spyse"`
-	URLScan              string `json:"urlscan"`
-	Virustotal           string `json:"virustotal"`
-	ZoomEyeUsername      string `json:"zoomeye_username"`
-	ZoomEyePassword      string `json:"zoomeye_password"`
+	IntelXHost           string   `json:"intelXHost"`
+	IntelXKey            string   `json:"intelXKey"`
+	PassiveTotalUsername string   `json:"passivetotal_username"`
+	PassiveTotalPassword string   `json:"passivetotal_password"`
+	Securitytrails       string   `json:"securitytrails"`
+	Shodan               string   `json:"shodan"`
+	Spyse                string   `json:"spyse"`
+	URLScan              string   `json:"urlscan"`
+	Virustotal           string   `json:"virustotal"`
+	ZoomEyeUsername      string   `json:"zoomeye_username"`
+	ZoomEyePassword      string   `json:"zoomeye_password"`
 }
 
 // Result is a result structure returned by a source

--- a/pkg/subscraping/types.go
+++ b/pkg/subscraping/types.go
@@ -22,7 +22,7 @@ type Session struct {
 	// Extractor is the regex for subdomains created for each domain
 	Extractor *regexp.Regexp
 	// Keys is the API keys for the application
-	Keys Keys
+	Keys *Keys
 	// Client is the current http client
 	Client *http.Client
 }


### PR DESCRIPTION
Implements #277

Needs revision, it should be set as a draft for further improvement before confirming the merge.

There are several linters that I have disabled because for now it is a lot of work to correct the errors, for example

- `funlen`: Detection of long functions.
- `gocyclo`: Calculates  [cyclomatic complexities](https://en.wikipedia.org/wiki/Cyclomatic_complexity).
- `gosec`: Inspects source code for security problems.
- `lll`: Line length linter, used to enforce line length in files.

and I have added some directives to skip the checks with (`nolint`) because they need a small refactor but I think it's fine for now, we can improve it in the future.

Changes need in-depth review to make sure nothing is broken and that they are appropriate.

If you want to test this locally with https://github.com/nektos/act you'll have to add an additional step before `"Set up Go"` due to a dependencies error of the `nektos/act` default docker image.

```
    steps:
      - name: Install dependencies
        run: |
          apt update
          apt install gcc build-essential --assume-yes --quiet --no-install-suggests --no-install-recommends

      - name: Set up Go
        uses: actions/setup-go@v2
        with:
          go-version: 1.13
```
Note I added a new step `golangci-lint` after `Build` step instead of adding a new workflow file as https://github.com/golangci/golangci-lint-action#how-to-use recommends, but in the future we could move it to its own file to have better control over the actions of the GitHub workflow.

I think the configuration is not very strict but it ensures a minimum quality of the code, if you consider it appropriate we can add other linters to make it more strict, but we have to think about it in order to facilitate the work of the collaborators in new pull requests.

We have an open discussion here.

I have do my best, I apologize in advance for any possible problems that may arise.