### PR TITLE
Sources memory improvement

### DIFF
--- a/pkg/subscraping/sources/alienvault/alienvault.go
+++ b/pkg/subscraping/sources/alienvault/alienvault.go
@@ -22,28 +22,27 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
+		defer close(results)
+
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://otx.alienvault.com/api/v1/indicators/domain/%s/passive_dns", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)
-			close(results)
 			return
 		}
 
-		otxResp := &alienvaultResponse{}
+		var response alienvaultResponse
 		// Get the response body and decode
-		err = json.NewDecoder(resp.Body).Decode(&otxResp)
+		err = json.NewDecoder(resp.Body).Decode(&response)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			resp.Body.Close()
-			close(results)
 			return
 		}
 		resp.Body.Close()
-		for _, record := range otxResp.PassiveDNS {
+		for _, record := range response.PassiveDNS {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: record.Hostname}
 		}
-		close(results)
 	}()
 
 	return results

--- a/pkg/subscraping/sources/archiveis/archiveis.go
+++ b/pkg/subscraping/sources/archiveis/archiveis.go
@@ -3,6 +3,7 @@ package archiveis
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"regexp"
 
@@ -33,14 +34,15 @@ func (a *ArchiveIs) enumerate(ctx context.Context, baseURL string) {
 
 	// Get the response body
 	body, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
 	if err != nil {
 		a.Results <- subscraping.Result{Source: "archiveis", Type: subscraping.Error, Error: err}
+		resp.Body.Close()
 		return
 	}
 
-	src := string(body)
+	resp.Body.Close()
 
+	src := string(body)
 	for _, subdomain := range a.Session.Extractor.FindAllString(src, -1) {
 		a.Results <- subscraping.Result{Source: "archiveis", Type: subscraping.Subdomain, Value: subdomain}
 	}
@@ -64,7 +66,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	}
 
 	go func() {
-		aInstance.enumerate(ctx, "http://archive.is/*."+domain)
+		aInstance.enumerate(ctx, fmt.Sprintf("http://archive.is/*.%s", domain))
 		close(aInstance.Results)
 	}()
 

--- a/pkg/subscraping/sources/commoncrawl/commoncrawl.go
+++ b/pkg/subscraping/sources/commoncrawl/commoncrawl.go
@@ -1,9 +1,9 @@
 package commoncrawl
 
 import (
+	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"strings"
 
@@ -28,20 +28,20 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
+		defer close(results)
+
 		resp, err := session.SimpleGet(ctx, indexURL)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)
-			close(results)
 			return
 		}
 
-		indexes := []indexResponse{}
+		var indexes []indexResponse
 		err = jsoniter.NewDecoder(resp.Body).Decode(&indexes)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			resp.Body.Close()
-			close(results)
 			return
 		}
 		resp.Body.Close()
@@ -64,7 +64,6 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				break
 			}
 		}
-		close(results)
 	}()
 
 	return results
@@ -81,27 +80,32 @@ func (s *Source) getSubdomains(ctx context.Context, searchURL, domain string, se
 		case <-ctx.Done():
 			return false
 		default:
-			resp, err := session.SimpleGet(ctx, fmt.Sprintf("%s?url=*.%s&output=json", searchURL, domain))
+			var headers = map[string]string{"Host": "index.commoncrawl.org"}
+			resp, err := session.Get(ctx, fmt.Sprintf("%s?url=*.%s", searchURL, domain), "", headers)
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+				session.DiscardHTTPResponse(resp)
 				return false
 			}
 
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-				resp.Body.Close()
-				return false
+			scanner := bufio.NewScanner(resp.Body)
+			for scanner.Scan() {
+				line := scanner.Text()
+				if line == "" {
+					continue
+				}
+				line, _ = url.QueryUnescape(line)
+				subdomain := session.Extractor.FindString(line)
+				if subdomain != "" {
+					// fix for triple encoded URL
+					subdomain = strings.ToLower(subdomain)
+					subdomain = strings.TrimPrefix(subdomain, "25")
+					subdomain = strings.TrimPrefix(subdomain, "2f")
+
+					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+				}
 			}
 			resp.Body.Close()
-
-			src, _ := url.QueryUnescape(string(body))
-
-			for _, subdomain := range session.Extractor.FindAllString(src, -1) {
-				subdomain = strings.TrimPrefix(subdomain, "25")
-
-				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
-			}
 			return true
 		}
 	}

--- a/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/pkg/subscraping/sources/crtsh/crtsh.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
-	"strings"
+
+	jsoniter "github.com/json-iterator/go"
 
 	// postgres driver
 	_ "github.com/lib/pq"
 	"github.com/projectdiscovery/subfinder/pkg/subscraping"
 )
+
+type subdomain struct {
+	ID        int    `json:"id"`
+	NameValue string `json:"name_value"`
+}
 
 // Source is the passive scraping agent
 type Source struct{}
@@ -20,13 +25,12 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
+		defer close(results)
 		found := s.getSubdomainsFromSQL(domain, results)
 		if found {
-			close(results)
 			return
 		}
 		_ = s.getSubdomainsFromHTTP(ctx, domain, session, results)
-		close(results)
 	}()
 
 	return results
@@ -74,20 +78,20 @@ func (s *Source) getSubdomainsFromHTTP(ctx context.Context, domain string, sessi
 		return false
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	var subdomains []subdomain
+	err = jsoniter.NewDecoder(resp.Body).Decode(&subdomains)
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 		resp.Body.Close()
 		return false
 	}
+
 	resp.Body.Close()
 
-	// Also replace all newlines
-	src := strings.ReplaceAll(string(body), "\\n", " ")
-
-	for _, subdomain := range session.Extractor.FindAllString(src, -1) {
-		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+	for _, subdomain := range subdomains {
+		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain.NameValue}
 	}
+
 	return true
 }
 

--- a/pkg/subscraping/sources/dnsdb/dnsdb.go
+++ b/pkg/subscraping/sources/dnsdb/dnsdb.go
@@ -2,11 +2,12 @@ package dnsdb
 
 import (
 	"bufio"
+	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/projectdiscovery/subfinder/pkg/subscraping"
 )
 
@@ -21,46 +22,42 @@ type Source struct{}
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
 
-	if session.Keys.DNSDB == "" {
-		close(results)
-	} else {
+	go func() {
+		defer close(results)
+
+		if session.Keys.DNSDB == "" {
+			return
+		}
+
 		headers := map[string]string{
 			"X-API-KEY":    session.Keys.DNSDB,
 			"Accept":       "application/json",
 			"Content-Type": "application/json",
 		}
 
-		go func() {
-			resp, err := session.Get(ctx, fmt.Sprintf("https://api.dnsdb.info/lookup/rrset/name/*.%s?limit=1000000000000", domain), "", headers)
+		resp, err := session.Get(ctx, fmt.Sprintf("https://api.dnsdb.info/lookup/rrset/name/*.%s?limit=1000000000000", domain), "", headers)
+		if err != nil {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			session.DiscardHTTPResponse(resp)
+			return
+		}
+
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+			var response dnsdbResponse
+			err = jsoniter.NewDecoder(bytes.NewBufferString(line)).Decode(&response)
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-				session.DiscardHTTPResponse(resp)
-				close(results)
 				return
 			}
-
-			defer resp.Body.Close()
-			// Get the response body
-			scanner := bufio.NewScanner(resp.Body)
-			for scanner.Scan() {
-				line := scanner.Text()
-				if line == "" {
-					continue
-				}
-				out := &dnsdbResponse{}
-				err := json.Unmarshal([]byte(line), out)
-				if err != nil {
-					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-					resp.Body.Close()
-					close(results)
-					return
-				}
-				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: strings.TrimSuffix(out.Name, ".")}
-				out = nil
-			}
-			close(results)
-		}()
-	}
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: strings.TrimSuffix(response.Name, ".")}
+		}
+		resp.Body.Close()
+	}()
 	return results
 }
 

--- a/pkg/subscraping/sources/entrust/entrust.go
+++ b/pkg/subscraping/sources/entrust/entrust.go
@@ -17,11 +17,12 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
+		defer close(results)
+
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://ctsearch.entrust.com/api/v1/certificates?fields=issuerCN,subjectO,issuerDN,issuerO,subjectDN,signAlg,san,publicKeyType,publicKeySize,validFrom,validTo,sn,ev,logEntries.logName,subjectCNReversed,cert&domain=%s&includeExpired=true&exactMatch=false&limit=5000", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)
-			close(results)
 			return
 		}
 
@@ -29,19 +30,16 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			resp.Body.Close()
-			close(results)
 			return
 		}
 		resp.Body.Close()
 
 		src := string(body)
-
 		for _, subdomain := range session.Extractor.FindAllString(src, -1) {
 			subdomain = strings.TrimPrefix(subdomain, "u003d")
 
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 		}
-		close(results)
 	}()
 
 	return results

--- a/pkg/subscraping/sources/hackertarget/hackertarget.go
+++ b/pkg/subscraping/sources/hackertarget/hackertarget.go
@@ -1,9 +1,9 @@
 package hackertarget
 
 import (
+	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 
 	"github.com/projectdiscovery/subfinder/pkg/subscraping"
 )
@@ -16,29 +16,28 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
+		defer close(results)
+
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("http://api.hackertarget.com/hostsearch/?q=%s", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)
-			close(results)
 			return
 		}
 
-		// Get the response body
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			resp.Body.Close()
-			close(results)
-			return
-		}
-		resp.Body.Close()
-		src := string(body)
+		defer resp.Body.Close()
 
-		for _, match := range session.Extractor.FindAllString(src, -1) {
-			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: match}
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+			match := session.Extractor.FindAllString(line, -1)
+			for _, subdomain := range match {
+				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+			}
 		}
-		close(results)
 	}()
 
 	return results

--- a/pkg/subscraping/sources/rapiddns/rapiddns.go
+++ b/pkg/subscraping/sources/rapiddns/rapiddns.go
@@ -17,6 +17,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 	go func() {
 		defer close(results)
+
 		resp, err := session.SimpleGet(ctx, "https://rapiddns.io/subdomain/"+domain+"?full=1")
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
@@ -25,11 +26,13 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		}
 
 		body, err := ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			resp.Body.Close()
 			return
 		}
+
+		resp.Body.Close()
 
 		src := string(body)
 		for _, subdomain := range session.Extractor.FindAllString(src, -1) {

--- a/pkg/subscraping/sources/sitedossier/sitedossier.go
+++ b/pkg/subscraping/sources/sitedossier/sitedossier.go
@@ -44,8 +44,8 @@ func (a *agent) enumerate(ctx context.Context, baseURL string) error {
 				return err
 			}
 			resp.Body.Close()
-			src := string(body)
 
+			src := string(body)
 			for _, match := range a.session.Extractor.FindAllString(src, -1) {
 				a.results <- subscraping.Result{Source: "sitedossier", Type: subscraping.Subdomain, Value: match}
 			}

--- a/pkg/subscraping/sources/sublist3r/subllist3r.go
+++ b/pkg/subscraping/sources/sublist3r/subllist3r.go
@@ -16,28 +16,28 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
+		defer close(results)
+
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://api.sublist3r.com/search.php?domain=%s", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)
-			close(results)
 			return
 		}
-		defer resp.Body.Close()
+
 		var subdomains []string
-		// Get the response body and unmarshal
 		err = json.NewDecoder(resp.Body).Decode(&subdomains)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			resp.Body.Close()
-			close(results)
 			return
 		}
+
+		resp.Body.Close()
 
 		for _, subdomain := range subdomains {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 		}
-		close(results)
 	}()
 
 	return results

--- a/pkg/subscraping/sources/threatminer/threatminer.go
+++ b/pkg/subscraping/sources/threatminer/threatminer.go
@@ -3,10 +3,17 @@ package threatminer
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/projectdiscovery/subfinder/pkg/subscraping"
 )
+
+type response struct {
+	StatusCode    string   `json:"status_code"`
+	StatusMessage string   `json:"status_message"`
+	Results       []string `json:"results"`
+}
 
 // Source is the passive scraping agent
 type Source struct{}
@@ -16,30 +23,27 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
+		defer close(results)
+
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://api.threatminer.org/v2/domain.php?q=%s&rt=5", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)
-			close(results)
 			return
 		}
 
-		// Get the response body
-		body, err := ioutil.ReadAll(resp.Body)
+		defer resp.Body.Close()
+
+		var data response
+		err = jsoniter.NewDecoder(resp.Body).Decode(&data)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			resp.Body.Close()
-			close(results)
 			return
 		}
-		resp.Body.Close()
 
-		src := string(body)
-
-		for _, match := range session.Extractor.FindAllString(src, -1) {
-			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: match}
+		for _, subdomain := range data.Results {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 		}
-		close(results)
 	}()
 
 	return results

--- a/pkg/subscraping/sources/waybackarchive/waybackarchive.go
+++ b/pkg/subscraping/sources/waybackarchive/waybackarchive.go
@@ -1,9 +1,10 @@
 package waybackarchive
 
 import (
+	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"net/url"
 	"strings"
 
 	"github.com/projectdiscovery/subfinder/pkg/subscraping"
@@ -17,31 +18,34 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		pagesResp, err := session.SimpleGet(ctx, fmt.Sprintf("http://web.archive.org/cdx/search/cdx?url=*.%s/*&output=json&fl=original&collapse=urlkey", domain))
+		defer close(results)
+
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("http://web.archive.org/cdx/search/cdx?url=*.%s/*&output=txt&fl=original&collapse=urlkey", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			session.DiscardHTTPResponse(pagesResp)
-			close(results)
+			session.DiscardHTTPResponse(resp)
 			return
 		}
 
-		body, err := ioutil.ReadAll(pagesResp.Body)
-		if err != nil {
-			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-			pagesResp.Body.Close()
-			close(results)
-			return
-		}
-		pagesResp.Body.Close()
+		defer resp.Body.Close()
 
-		match := session.Extractor.FindAllString(string(body), -1)
-		for _, subdomain := range match {
-			subdomain = strings.TrimPrefix(subdomain, "25")
-			subdomain = strings.TrimPrefix(subdomain, "2F")
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+			line, _ = url.QueryUnescape(line)
+			subdomain := session.Extractor.FindString(line)
+			if subdomain != "" {
+				// fix for triple encoded URL
+				subdomain = strings.ToLower(subdomain)
+				subdomain = strings.TrimPrefix(subdomain, "25")
+				subdomain = strings.TrimPrefix(subdomain, "2f")
 
-			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+			}
 		}
-		close(results)
 	}()
 
 	return results


### PR DESCRIPTION
Fixes #279

This branch comes from the same branch of #278 (commit https://github.com/projectdiscovery/subfinder/pull/281/commits/34fb96f0605401144baff0778926d74f178cc13e)

I leave the pull request here to not to lose the local changes, we should merge it after the mentioned pull request we could also put it as a draft to release it after.

Main changes:

Decodes `JSON`  instead of reading all the response content into memory and  parsing with `regex`:

- `bufferover`
- `certspotterold`
- `crtsh`
- `threatcrowd`
- `threatminer`

Read responses using `bufio` instead of `ioutil.ReadAll`

- `github`
- `commoncrawl`
- `hackertarget`
- `waybackarchive`

Fixes triple URL encoding:

- `commoncrawl`
- `waybackarchive`

Check it and tell me what you think!