### PR TITLE
Handle sitedossier 404 when no subdomains are found

### DIFF
--- a/pkg/subscraping/sources/sitedossier/sitedossier.go
+++ b/pkg/subscraping/sources/sitedossier/sitedossier.go
@@ -39,10 +39,6 @@ func (a *agent) enumerate(ctx context.Context, baseURL string) error {
 				return err
 			}
 
-			if isnotfound {
-				return nil
-			}
-
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
 				a.results <- subscraping.Result{Source: "sitedossier", Type: subscraping.Error, Error: err}


### PR DESCRIPTION
sitedossier returns a 404 error when no subdomains are found.