### PR TITLE
Fixed GitHub search query term + sort results

### DIFF
--- a/pkg/subscraping/sources/github/github.go
+++ b/pkg/subscraping/sources/github/github.go
@@ -51,8 +51,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 		tokens := NewTokenManager(session.Keys.GitHub)
 
-		// search on GitHub with exact match
-		searchURL := fmt.Sprintf("https://api.github.com/search/code?per_page=100&q=\"%s\"", domain)
+		searchURL := fmt.Sprintf("https://api.github.com/search/code?per_page=100&q=%s&sort=created&order=asc", domain)
 		s.enumerate(ctx, searchURL, domainRegexp(domain), tokens, session, results)
 	}()
 


### PR DESCRIPTION
The double quotes arround the search term does not return any results for some terms like "tesla.com".