### PR TITLE
Added Connection: close request header

### DIFF
--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -68,6 +68,7 @@ func (s *Session) HTTPRequest(ctx context.Context, method, requestURL, cookies s
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36")
 	req.Header.Set("Accept", "*/*")
 	req.Header.Set("Accept-Language", "en")
+	req.Header.Set("Connection", "close")
 
 	if basicAuth.Username != "" || basicAuth.Password != "" {
 		req.SetBasicAuth(basicAuth.Username, basicAuth.Password)

--- a/pkg/subscraping/sources/bufferover/bufferover.go
+++ b/pkg/subscraping/sources/bufferover/bufferover.go
@@ -4,6 +4,7 @@ package bufferover
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -11,6 +12,9 @@ import (
 )
 
 type response struct {
+	Meta struct {
+		Errors []string `json:"Errors"`
+	} `json:"Meta"`
 	FDNSA   []string `json:"FDNS_A"`
 	RDNS    []string `json:"RDNS"`
 	Results []string `json:"Results"`
@@ -36,7 +40,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 func (s *Source) getData(ctx context.Context, sourceURL string, session *subscraping.Session, results chan subscraping.Result) {
 	resp, err := session.SimpleGet(ctx, sourceURL)
-	if err != nil {
+	if err != nil && resp == nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 		session.DiscardHTTPResponse(resp)
 		return
@@ -51,6 +55,13 @@ func (s *Source) getData(ctx context.Context, sourceURL string, session *subscra
 	}
 
 	resp.Body.Close()
+
+	metaErrors := bufforesponse.Meta.Errors
+
+	if len(metaErrors) > 0 {
+		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: fmt.Errorf("%s", strings.Join(metaErrors[:], ", "))}
+		return
+	}
 
 	var subdomains []string
 

--- a/pkg/subscraping/sources/bufferover/bufferover.go
+++ b/pkg/subscraping/sources/bufferover/bufferover.go
@@ -59,7 +59,7 @@ func (s *Source) getData(ctx context.Context, sourceURL string, session *subscra
 	metaErrors := bufforesponse.Meta.Errors
 
 	if len(metaErrors) > 0 {
-		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: fmt.Errorf("%s", strings.Join(metaErrors[:], ", "))}
+		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: fmt.Errorf("%s", strings.Join(metaErrors, ", "))}
 		return
 	}
 

--- a/pkg/subscraping/sources/ipv4info/ipv4info.go
+++ b/pkg/subscraping/sources/ipv4info/ipv4info.go
@@ -2,7 +2,9 @@ package ipv4info
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
+	"net/http"
 	"regexp"
 	"strconv"
 
@@ -19,8 +21,8 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	go func() {
 		defer close(results)
 
-		resp, err := session.SimpleGet(ctx, "http://ipv4info.com/search/"+domain)
-		if err != nil {
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("http://ipv4info.com/search/%s", domain))
+		if err != nil && resp == nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)
 			return
@@ -35,6 +37,12 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp.Body.Close()
 
 		src := string(body)
+
+		if resp.StatusCode != http.StatusOK {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: fmt.Errorf("%s", src)}
+			return
+		}
+
 		regxTokens := regexp.MustCompile("/ip-address/(.*)/" + domain)
 		matchTokens := regxTokens.FindAllString(src, -1)
 


### PR DESCRIPTION
Tries to fix #250.

A significant difference between HTTP/1.1 and earlier versions of HTTP is that persistent connections are the default behaviour of any HTTP connection.

http://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html

We inform the server that the client wants to close the connection after the transaction is complete by setting the Connection header.

Handles response errors for:

- `bufferover`
- `certspotterold`
- `ipv4info`