### PR TITLE
recon.dev: fix token

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Subfinder will work after using the installation instructions however to configu
 - [Zoomeye](https://www.zoomeye.org)
 - [Github](https://github.com)
 - [Intelx](https://intelx.io)
+- [Recon](https://recon.dev)
 
 Theses values are stored in the `$HOME/.config/subfinder/config.yaml` file which will be created when you run the tool for the first time. The configuration file uses the YAML format. Multiple API keys can be specified for each of these services from which one of them will be used for enumeration.
 

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -37,6 +37,7 @@ type ConfigFile struct {
 	GitHub         []string `yaml:"github"`
 	IntelX         []string `yaml:"intelx"`
 	PassiveTotal   []string `yaml:"passivetotal"`
+	Recon          []string `yaml:"recon"`
 	SecurityTrails []string `yaml:"securitytrails"`
 	Shodan         []string `yaml:"shodan"`
 	Spyse          []string `yaml:"spyse"`
@@ -155,6 +156,10 @@ func (c *ConfigFile) GetKeys() subscraping.Keys {
 			keys.PassiveTotalUsername = parts[0]
 			keys.PassiveTotalPassword = parts[1]
 		}
+	}
+
+	if len(c.Recon) > 0 {
+		keys.Recon = c.Recon[rand.Intn(len(c.Recon))]
 	}
 
 	if len(c.SecurityTrails) > 0 {

--- a/pkg/subscraping/sources/recon/recon.go
+++ b/pkg/subscraping/sources/recon/recon.go
@@ -22,7 +22,11 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	go func() {
 		defer close(results)
 
-		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://api.recon.dev/search?domain=%s", domain))
+		if session.Keys.Recon == "" {
+			return
+		}
+
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://api.recon.dev/search?key=%s&domain=%s", session.Keys.Recon, domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/sources/recon/recon.go
+++ b/pkg/subscraping/sources/recon/recon.go
@@ -26,7 +26,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
-		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://api.recon.dev/search?key=%s&domain=%s", session.Keys.Recon, domain))
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://recon.dev/api/search?key=%s&domain=%s", session.Keys.Recon, domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)

--- a/pkg/subscraping/types.go
+++ b/pkg/subscraping/types.go
@@ -46,6 +46,7 @@ type Keys struct {
 	IntelXKey            string   `json:"intelXKey"`
 	PassiveTotalUsername string   `json:"passivetotal_username"`
 	PassiveTotalPassword string   `json:"passivetotal_password"`
+	Recon                string   `json:"recon"`
 	Securitytrails       string   `json:"securitytrails"`
 	Shodan               string   `json:"shodan"`
 	Spyse                string   `json:"spyse"`


### PR DESCRIPTION
recon.dev now requires a token.
this pr adds token handling of recon.dev
api docs are here: [API](https://recon.dev/api/docs)