### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,7 @@ jobs:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.29
           args: --timeout 5m
+          working-directory: v2/cmd/subfinder/
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
We need to set the working directory to allow golangci-lint to resolve go modules.