### PR TITLE
Fixed multi-stage build, reduced docker image to 19MB. Was 500MB.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,8 @@ FROM golang:1.13.4-alpine3.10 AS build-env
 MAINTAINER Ice3man (nizamul@projectdiscovery.io)
 RUN apk add --no-cache --upgrade git openssh-client ca-certificates
 RUN go get -u github.com/golang/dep/cmd/dep
-WORKDIR /go/src/app
-
-# Install
 RUN go get -u github.com/projectdiscovery/subfinder/v2/cmd/subfinder
 
+FROM alpine:latest
+COPY --from=build-env /go/bin/subfinder /usr/local/bin/
 ENTRYPOINT ["subfinder"]


### PR DESCRIPTION
- Remove unnecessary `WORKDIR`
- Correct the multi-stage build that was started originally `AS build-env` 
- Reduced image from 500MB to 19MB