### PR TITLE
fix(sitedossier): return early when errors are hit

### DIFF
--- a/v2/pkg/subscraping/sources/sitedossier/sitedossier.go
+++ b/v2/pkg/subscraping/sources/sitedossier/sitedossier.go
@@ -35,12 +35,14 @@ func (a *agent) enumerate(ctx context.Context, baseURL string) {
 	if err != nil && !isnotfound {
 		a.results <- subscraping.Result{Source: "sitedossier", Type: subscraping.Error, Error: err}
 		a.session.DiscardHTTPResponse(resp)
+		return
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		a.results <- subscraping.Result{Source: "sitedossier", Type: subscraping.Error, Error: err}
 		resp.Body.Close()
+		return
 	}
 	resp.Body.Close()
 


### PR DESCRIPTION
this avoids a nil pointer access on resp.Body when a 404 is returned

Mitigates against the panic:
```
 panic: runtime error: invalid memory address or nil pointer dereference                                                                                                                                                                        
 [signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0xce6270]                                                                                                                                                                        
 goroutine 276 [running]:                                                                                                                                                                                                                       
 github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/sitedossier.(*agent).enumerate(0xc0003a7480, 0x34f37a0, 0xc0005de420, 0xc000d51c00, 0x34)                                                                                     
     /go/pkg/mod/github.com/projectdiscovery/subfinder/v2@v2.4.5/pkg/subscraping/sources/sitedossier/sitedossier.go:40 +0x190                                                                                                                   
 github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/sitedossier.(*Source).Run.func1(0xc0003a7480, 0x34f37a0, 0xc0005de420, 0xc001788c80, 0xc)                                                                                     
     /go/pkg/mod/github.com/projectdiscovery/subfinder/v2@v2.4.5/pkg/subscraping/sources/sitedossier/sitedossier.go:73 +0xc2                                                                                                                    
 created by github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/sitedossier.(*Source).Run                                                                                                                                          
     /go/pkg/mod/github.com/projectdiscovery/subfinder/v2@v2.4.5/pkg/subscraping/sources/sitedossier/sitedossier.go:72 +0xc0     
```