### PR TITLE
Improved Github subdomain matching regex

### DIFF
--- a/v2/pkg/subscraping/sources/github/github.go
+++ b/v2/pkg/subscraping/sources/github/github.go
@@ -183,7 +183,7 @@ func rawURL(htmlURL string) string {
 // DomainRegexp regular expression to match subdomains in github files code
 func domainRegexp(domain string) *regexp.Regexp {
 	rdomain := strings.ReplaceAll(domain, ".", "\\.")
-	return regexp.MustCompile("(\\w+[.])*" + rdomain)
+	return regexp.MustCompile("(\\w[a-zA-Z0-9][a-zA-Z0-9-\\.]*)" + rdomain)
 }
 
 // Name returns the name of the source


### PR DESCRIPTION
The Regular Expression for matching subdomains did not match on hyphens (`-`) which created a lot of situations where subdomains were being incompletely picked up.

For example, `foo-bar.foobar.com` would only match on `bar.foobar.com`. Also added a match on only-alphanum for the first character, as subdomains can't start with `-`.