### PR TITLE
fix(crtsh): typo preventing results being returned fixed

### DIFF
--- a/v2/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/v2/pkg/subscraping/sources/crtsh/crtsh.go
@@ -72,7 +72,7 @@ func (s *Source) getSubdomainsFromSQL(domain string, results chan subscraping.Re
 }
 
 func (s *Source) getSubdomainsFromHTTP(ctx context.Context, domain string, session *subscraping.Session, results chan subscraping.Result) bool {
-	resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://crt.sh/?q=%%25.%s&output=json", domain))
+	resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://crt.sh/?q=%25.%s&output=json", domain))
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 		session.DiscardHTTPResponse(resp)


### PR DESCRIPTION
There's an extra % in the crt.sh API endpoint that prevents results from being returned. I've fixed this typo so that this source works again.