### PR TITLE
Crtsh: properly close database connection

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -7,7 +7,7 @@ GOGET=$(GOCMD) get
     
 all: build
 build:
-		$(GOBUILD) -v -ldflags="-extldflags=-static" -o "subfiner" cmd/nuclei/main.go
+		$(GOBUILD) -v -ldflags="-extldflags=-static" -o "subfinder" cmd/subfinder/main.go
 test: 
 		$(GOTEST) -v ./...
 tidy:

--- a/v2/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/v2/pkg/subscraping/sources/crtsh/crtsh.go
@@ -44,6 +44,8 @@ func (s *Source) getSubdomainsFromSQL(domain string, results chan subscraping.Re
 		return 0
 	}
 
+	defer db.Close()
+
 	pattern := "%." + domain
 	query := `SELECT DISTINCT ci.NAME_VALUE as domain FROM certificate_identity ci
 					  WHERE reverse(lower(ci.NAME_VALUE)) LIKE reverse(lower($1))


### PR DESCRIPTION
I managed to track down a socket leak to the crtsh source. This probably wouldn't have been noticeable via the command line as resources are automatically freed after the process exits. Unfortunately, it does become a problem when importing subfinder as a library. Closing the database connection appears to fix the leak.