### PR TITLE
dnsdumpster is not working. The bug has been fixed.

### DIFF
--- a/v2/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/v2/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -30,6 +30,7 @@ func postForm(ctx context.Context, session *subscraping.Session, token, domain s
 	params := url.Values{
 		"csrfmiddlewaretoken": {token},
 		"targetip":            {domain},
+		"user":                {"free"},
 	}
 
 	resp, err := session.HTTPRequest(


### PR DESCRIPTION
DNSdumpster website has added one extra parameter when the form is being posted. The new parameter is the "user=free".