### PR TITLE
Add http-proxy flag and C99 to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,31 +53,31 @@ subfinder -h
 ```
 This will display help for the tool. Here are all the switches it supports.
 
-| Flag             | Description                                                | Example                                |
-| ---------------- | ---------------------------------------------------------- | -------------------------------------- |
-| -all             | Use all sources (slow) for enumeration                     | subfinder -d uber.com -all             |
-| -config          | Configuration file for API Keys, etc                       | subfinder -config config.yaml          |
-| -d               | Domain to find subdomains for                              | subfinder -d uber.com                  |
-| -dL              | File containing list of domains to enumerate               | subfinder -dL hackerone-hosts.txt      |
-| -exclude-sources | List of sources to exclude from enumeration                | subfinder -exclude-sources archiveis   |
-| -max-time        | Minutes to wait for enumeration results (default 10)       | subfinder -max-time 1                  |
-| -nC              | Don't Use colors in output                                 | subfinder -nC                          |
-| -nW              | Remove Wildcard & Dead Subdomains from output              | subfinder -nW                          |
-| -ls              | List all available sources                                 | subfinder -ls                          |
-| -o               | File to write output to (optional)                         | subfinder -o output.txt                |
-| -oD              | Directory to write enumeration results to (optional)       | subfinder -oD ~/outputs                |
-| -oI              | Write output in Host,IP format                             | subfinder -oI                          |
-| -oJ              | Write output in JSON lines Format                          | subfinder -oJ                          |
-| -r               | Comma-separated list of resolvers to use                   | subfinder -r 1.1.1.1,1.0.0.1           |
-| -rL              | Text file containing list of resolvers to use              | subfinder -rL resolvers.txt            |
-| -recursive       | Enumeration recursive subdomains                           | subfinder -d news.yahoo.com -recursive |
-| -silent          | Show only subdomains in output                             | subfinder -silent                      |
-| -sources         | Comma separated list of sources to use                     | subfinder -sources shodan,censys       |
-| -t               | Number of concurrent goroutines for resolving (default 10) | subfinder -t 100                       |
-| -timeout         | Seconds to wait before timing out (default 30)             | subfinder -timeout 30                  |
-| -http-proxy      | Http Proxy                                                 | subfinder -http-proxy http://localhost:3128
-| -v               | Show Verbose output                                        | subfinder -v                           |
-| -version         | Show current program version                               | subfinder -version                     |
+| Flag             | Description                                                | Example                                     |
+| ---------------- | ---------------------------------------------------------- | --------------------------------------------|
+| -all             | Use all sources (slow) for enumeration                     | subfinder -d uber.com -all                  |
+| -config          | Configuration file for API Keys, etc                       | subfinder -config config.yaml               |
+| -d               | Domain to find subdomains for                              | subfinder -d uber.com                       |
+| -dL              | File containing list of domains to enumerate               | subfinder -dL hackerone-hosts.txt           |
+| -exclude-sources | List of sources to exclude from enumeration                | subfinder -exclude-sources archiveis        |
+| -max-time        | Minutes to wait for enumeration results (default 10)       | subfinder -max-time 1                       |
+| -nC              | Don't Use colors in output                                 | subfinder -nC                               |
+| -nW              | Remove Wildcard & Dead Subdomains from output              | subfinder -nW                               |
+| -ls              | List all available sources                                 | subfinder -ls                               |
+| -o               | File to write output to (optional)                         | subfinder -o output.txt                     |
+| -oD              | Directory to write enumeration results to (optional)       | subfinder -oD ~/outputs                     |
+| -oI              | Write output in Host,IP format                             | subfinder -oI                               |
+| -oJ              | Write output in JSON lines Format                          | subfinder -oJ                               |
+| -r               | Comma-separated list of resolvers to use                   | subfinder -r 1.1.1.1,1.0.0.1                |
+| -rL              | Text file containing list of resolvers to use              | subfinder -rL resolvers.txt                 |
+| -recursive       | Enumeration recursive subdomains                           | subfinder -d news.yahoo.com -recursive      |
+| -silent          | Show only subdomains in output                             | subfinder -silent                           |
+| -sources         | Comma separated list of sources to use                     | subfinder -sources shodan,censys            |
+| -t               | Number of concurrent goroutines for resolving (default 10) | subfinder -t 100                            |
+| -timeout         | Seconds to wait before timing out (default 30)             | subfinder -timeout 30                       |
+| -http-proxy      | Http Proxy                                                 | subfinder -http-proxy http://localhost:3128 |
+| -v               | Show Verbose output                                        | subfinder -v                                |
+| -version         | Show current program version                               | subfinder -version                          |
 
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This will display help for the tool. Here are all the switches it supports.
 | -sources         | Comma separated list of sources to use                     | subfinder -sources shodan,censys       |
 | -t               | Number of concurrent goroutines for resolving (default 10) | subfinder -t 100                       |
 | -timeout         | Seconds to wait before timing out (default 30)             | subfinder -timeout 30                  |
+| -http-proxy      | Http Proxy                                                 | subfinder -http-proxy http://localhost:3128
 | -v               | Show Verbose output                                        | subfinder -v                           |
 | -version         | Show current program version                               | subfinder -version                     |
 
@@ -93,6 +94,7 @@ Subfinder requires **go1.14+** to install successfully. Run the following comman
 Subfinder will work after using the installation instructions however to configure Subfinder to work with certain services, you will need to have setup API keys. The following services do not work without an API key:
 
 - [Binaryedge](https://binaryedge.io)
+- [C99](https://api.c99.nl/)
 - [Certspotter](https://sslmate.com/certspotter/api/)
 - [Censys](https://censys.io)
 - [Chaos](https://chaos.projectdiscovery.io)


### PR DESCRIPTION
I've added the `http-proxy` flag and C99 source to the readme file. I forgot to add them in when I added the features.