### PR TITLE
Modify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,20 @@
-# Build
-FROM golang:1.16.7-alpine AS build-env
+# Build image: golang:1.16.6-alpine3.14
+FROM golang@sha256:a8df40ad1380687038af912378f91cf26aeabb05046875df0bfedd38a79b5499 AS build
 RUN GO111MODULE=on go get -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder
 
-# Release
-FROM alpine:latest
+## Release image: alpine:3.14.1
+FROM alpine@sha256:be9bdc0ef8e96dbc428dc189b31e2e3b05523d96d12ed627c37aa2936653258c
+
 RUN apk -U upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates
-COPY --from=build-env /go/bin/subfinder /usr/local/bin/subfinder
+
+COPY --from=build /go/bin/subfinder /usr/local/bin/subfinder
+
+RUN adduser \
+    --gecos "" \
+    --disabled-password \
+    subfinder
+
+USER subfinder
 
 ENTRYPOINT ["subfinder"]


### PR DESCRIPTION
This PR modifies the Dockerfile in the following ways:
- Add deterministic image names
- Add a non-privileged user to the container. The importance of using a least privileged user is well-known, but you can check the advice from [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html) and [Snyk](https://snyk.io/blog/10-docker-image-security-best-practices/) if necessary. At the least, enabling such user makes it easy for those that use the Docker image and need to publish volumes (files are not written by root, making things easier)