### PR TITLE
Ask search engine scraping added

### DIFF
--- a/v2/pkg/passive/sources.go
+++ b/v2/pkg/passive/sources.go
@@ -16,6 +16,7 @@ import (
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/dnsdb"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/dnsdumpster"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/fofa"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/ask"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/github"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/hackertarget"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/intelx"
@@ -62,6 +63,7 @@ var DefaultSources = []string{
 	"threatminer",
 	"virustotal",
 	"fofa",
+	"ask",
 }
 
 // DefaultRecursiveSources contains list of default recursive sources
@@ -115,6 +117,7 @@ var DefaultAllSources = []string{
 	"waybackarchive",
 	"zoomeye",
 	"fofa",
+	"ask",
 }
 
 // Agent is a struct for running passive subdomain enumeration
@@ -207,6 +210,8 @@ func (a *Agent) addSources(sources []string) {
 			a.sources[source] = &zoomeye.Source{}
 		case "fofa":
 			a.sources[source] = &fofa.Source{}
+		case "ask":
+			a.sources[source] = &ask.Source{}
 		}
 	}
 }

--- a/v2/pkg/subscraping/sources/ask/ask.go
+++ b/v2/pkg/subscraping/sources/ask/ask.go
@@ -1,0 +1,90 @@
+// Package ask logic
+package ask
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+)
+
+// SleepRandIntn is the integer value to get the pseudo-random number
+// to sleep before find the next match
+const SleepRandIntn = 5
+
+var reNext = regexp.MustCompile(`<a href="([A-Za-z0-9/.]+)"><b>`)
+
+type agent struct {
+	results chan subscraping.Result
+	session *subscraping.Session
+}
+
+func (a *agent) enumerate(ctx context.Context, baseURL string) {
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
+	resp, err := a.session.SimpleGet(ctx, baseURL)
+	isnotfound := resp != nil && resp.StatusCode == http.StatusNotFound
+	if err != nil && !isnotfound {
+		a.results <- subscraping.Result{Source: "ask", Type: subscraping.Error, Error: err}
+		a.session.DiscardHTTPResponse(resp)
+		return
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		a.results <- subscraping.Result{Source: "ask", Type: subscraping.Error, Error: err}
+		resp.Body.Close()
+		return
+	}
+	resp.Body.Close()
+
+	src := string(body)
+	for _, match := range a.session.Extractor.FindAllString(src, -1) {
+		if !strings.Contains(match, "-www."){
+			a.results <- subscraping.Result{Source: "ask", Type: subscraping.Subdomain, Value: match}
+		}
+	}
+
+	match1 := reNext.FindStringSubmatch(src)
+	time.Sleep(time.Duration((3 + rand.Intn(SleepRandIntn))) * time.Second)
+
+	if len(match1) > 0 {
+		a.enumerate(ctx, "https://www.ask.com"+html.UnescapeString(match1[1]))
+	}
+}
+
+// Source is the passive scraping agent
+type Source struct{}
+
+// Run function returns all subdomains found with the service
+func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
+	results := make(chan subscraping.Result)
+
+	a := agent{
+		session: session,
+		results: results,
+	}
+
+	go func() {
+		a.enumerate(ctx, fmt.Sprintf("https://www.ask.com/web?q=site%%3A%s%%20-www.%s&o=0&l=dir&qo=pagination&page=1", domain, domain))
+		close(a.results)
+	}()
+
+	return a.results
+}
+
+// Name returns the name of the source
+func (s *Source) Name() string {
+	return "ask"
+}


### PR DESCRIPTION
`└─$ ./subfinder -d cloudflare.com -v -sources ask

               __    _____           __         
   _______  __/ /_  / __(_)___  ____/ /__  _____
  / ___/ / / / __ \/ /_/ / __ \/ __  / _ \/ ___/
 (__  ) /_/ / /_/ / __/ / / / / /_/ /  __/ /    
/____/\__,_/_.___/_/ /_/_/ /_/\__,_/\___/_/ v2.4.9

		projectdiscovery.io

Use with caution. You are responsible for your actions
Developers assume no liability and are not responsible for any misuse or damage.
By using subfinder, you also agree to the terms of the APIs used.

[INF] Enumerating subdomains for cloudflare.com
[ask] blog.cloudflare.com
[ask] developers.cloudflare.com
[ask] Source took 4.227402655s for enumeration
blog.cloudflare.com
developers.cloudflare.com
[INF] Found 2 subdomains for cloudflare.com in 4 seconds 227 milliseconds`