### PR TITLE
build: bump to go 1.17

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,13 +23,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-      - name: Set up Go
-        uses: actions/setup-go@v2
+      - uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.17
 
       - name: Test
         run: go test ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,27 +4,21 @@ on:
     tags:
       - v*
 
-jobs: 
-  release: 
+jobs:
+  release:
     runs-on: ubuntu-latest
-    steps: 
-      - 
-        name: "Check out code"
-        uses: actions/checkout@v2
-        with: 
-          fetch-depth: 0
-      - 
-        name: "Set up Go"
-        uses: actions/setup-go@v2
-        with: 
-          go-version: 1.15
-      - 
-        env: 
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      -
+        env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         name: "Create release on GitHub"
         uses: goreleaser/goreleaser-action@v2
-        with: 
+        with:
           args: "release --rm-dist"
           version: latest
           workdir: v2/
-        

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Build
-FROM golang:1.16.7-alpine AS build-env
+FROM golang:1.17-alpine AS build-env
 RUN GO111MODULE=on go get -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder
 
 # Release
-FROM alpine:latest
+FROM alpine:3.14
 RUN apk -U upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates
 COPY --from=build-env /go/bin/subfinder /usr/local/bin/subfinder

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectdiscovery/subfinder/v2
 
-go 1.16
+go 1.17
 
 require (
 	github.com/hako/durafmt v0.0.0-20210316092057-3a2c319c1acd
@@ -14,4 +14,17 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
+	github.com/miekg/dns v1.1.41 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/projectdiscovery/retryabledns v1.0.12-0.20210419174848-eec3ac17d61e // indirect
+	golang.org/x/net v0.0.0-20210415231046-e915ea6b2b7d // indirect
+	golang.org/x/sys v0.0.0-20210419170143-37df388d1f33 // indirect
 )


### PR DESCRIPTION
bump the project to use go1.17 and also refresh the workflow and dockerfile setup