### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 
 	"github.com/projectdiscovery/subfinder/v2/pkg/passive"
@@ -287,7 +286,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	data, err := ioutil.ReadAll(&buf)
+	data, err := io.ReadAll(&buf)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/v2/pkg/subscraping/agent.go
+++ b/v2/pkg/subscraping/agent.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -120,7 +119,7 @@ func (s *Session) HTTPRequest(ctx context.Context, method, requestURL, cookies s
 // DiscardHTTPResponse discards the response content by demand
 func (s *Session) DiscardHTTPResponse(response *http.Response) {
 	if response != nil {
-		_, err := io.Copy(ioutil.Discard, response.Body)
+		_, err := io.Copy(io.Discard, response.Body)
 		if err != nil {
 			gologger.Warning().Msgf("Could not discard response body: %s\n", err)
 			return

--- a/v2/pkg/subscraping/sources/archiveis/archiveis.go
+++ b/v2/pkg/subscraping/sources/archiveis/archiveis.go
@@ -4,7 +4,7 @@ package archiveis
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 )
@@ -32,7 +32,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			results <- subscraping.Result{Source: "archiveis", Type: subscraping.Error, Error: err}
 			resp.Body.Close()

--- a/v2/pkg/subscraping/sources/chinaz/chinaz.go
+++ b/v2/pkg/subscraping/sources/chinaz/chinaz.go
@@ -1,11 +1,13 @@
 package chinaz
+
 // chinaz  http://my.chinaz.com/ChinazAPI/DataCenter/MyDataApi
 import (
 	"context"
 	"fmt"
+	"io"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
-	"io/ioutil"
 )
 
 // Source is the passive scraping agent
@@ -29,16 +31,16 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 
 		resp.Body.Close()
 
-		SubdomainList :=jsoniter.Get(body, "Result").Get("ContributingSubdomainList")
+		SubdomainList := jsoniter.Get(body, "Result").Get("ContributingSubdomainList")
 
 		if SubdomainList.ToBool() {
 			_data := []byte(SubdomainList.ToString())
-			for i := 0 ; i< SubdomainList.Size() ; i++{
-				subdomain := jsoniter.Get(_data,i,"DataUrl").ToString()
+			for i := 0; i < SubdomainList.Size(); i++ {
+				subdomain := jsoniter.Get(_data, i, "DataUrl").ToString()
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 			}
 		} else {

--- a/v2/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/v2/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -4,7 +4,7 @@ package dnsdumpster
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"regexp"
 	"strings"
@@ -53,7 +53,7 @@ func postForm(ctx context.Context, session *subscraping.Session, token, domain s
 	}
 
 	// Now, grab the entire page
-	in, err := ioutil.ReadAll(resp.Body)
+	in, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	return string(in), err
 }
@@ -75,7 +75,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			resp.Body.Close()

--- a/v2/pkg/subscraping/sources/intelx/intelx.go
+++ b/v2/pkg/subscraping/sources/intelx/intelx.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
@@ -98,7 +98,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				return
 			}
 
-			_, err = ioutil.ReadAll(resp.Body)
+			_, err = io.ReadAll(resp.Body)
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 				resp.Body.Close()

--- a/v2/pkg/subscraping/sources/rapiddns/rapiddns.go
+++ b/v2/pkg/subscraping/sources/rapiddns/rapiddns.go
@@ -3,7 +3,7 @@ package rapiddns
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 )
@@ -25,7 +25,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			resp.Body.Close()

--- a/v2/pkg/subscraping/sources/sitedossier/sitedossier.go
+++ b/v2/pkg/subscraping/sources/sitedossier/sitedossier.go
@@ -4,7 +4,7 @@ package sitedossier
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"regexp"
@@ -39,7 +39,7 @@ func (a *agent) enumerate(ctx context.Context, baseURL string) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		a.results <- subscraping.Result{Source: "sitedossier", Type: subscraping.Error, Error: err}
 		resp.Body.Close()


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since subfinder has been upgraded to Go 1.17 (#460), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.