### PR TITLE
Add source zoomeye subdomain api 

### DIFF
--- a/v2/pkg/passive/sources.go
+++ b/v2/pkg/passive/sources.go
@@ -36,6 +36,7 @@ import (
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/virustotal"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/waybackarchive"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/zoomeye"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/zoomeyeapi"
 )
 
 // DefaultSources contains the list of fast sources used by default.
@@ -114,6 +115,7 @@ var DefaultAllSources = []string{
 	"virustotal",
 	"waybackarchive",
 	"zoomeye",
+	"zoomeyeapi",
 	"fofa",
 }
 
@@ -205,6 +207,8 @@ func (a *Agent) addSources(sources []string) {
 			a.sources[source] = &waybackarchive.Source{}
 		case "zoomeye":
 			a.sources[source] = &zoomeye.Source{}
+		case "zoomeyeapi":
+			a.sources[source] = &zoomeyeapi.Source{}
 		case "fofa":
 			a.sources[source] = &fofa.Source{}
 		}

--- a/v2/pkg/runner/config.go
+++ b/v2/pkg/runner/config.go
@@ -47,6 +47,7 @@ type ConfigFile struct {
 	URLScan        []string `yaml:"urlscan"`
 	Virustotal     []string `yaml:"virustotal"`
 	ZoomEye        []string `yaml:"zoomeye"`
+	ZoomEyeApi     []string `yaml:"zoomeyeapi"`
 	Fofa           []string `yaml:"fofa"`
 	// Version indicates the version of subfinder installed.
 	Version string `yaml:"subfinder-version"`
@@ -198,6 +199,9 @@ func (c *ConfigFile) GetKeys() subscraping.Keys {
 			keys.ZoomEyeUsername = parts[0]
 			keys.ZoomEyePassword = parts[1]
 		}
+	}
+	if len(c.ZoomEyeApi) > 0 {
+		keys.ZoomEyeKey = c.ZoomEyeApi[rand.Intn(len(c.ZoomEyeApi))]
 	}
 	if len(c.Fofa) > 0 {
 		fofaKeys := c.Fofa[rand.Intn(len(c.Fofa))]

--- a/v2/pkg/subscraping/sources/zoomeye/zoomeye.go
+++ b/v2/pkg/subscraping/sources/zoomeye/zoomeye.go
@@ -87,7 +87,6 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: domain}
 				}
 			}
-			currentPage++
 		}
 	}()
 

--- a/v2/pkg/subscraping/sources/zoomeyeapi/zoomeyeapi.go
+++ b/v2/pkg/subscraping/sources/zoomeyeapi/zoomeyeapi.go
@@ -59,15 +59,13 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			err = json.NewDecoder(resp.Body).Decode(&res)
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
-				resp.Body.Close()
+				_ = resp.Body.Close()
 				return
 			}
-			resp.Body.Close()
 			pages = int(res.Total/1000) + 1
 			for _, r := range res.List {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: r.Name}
 			}
-			currentPage++
 		}
 	}()
 

--- a/v2/pkg/subscraping/sources/zoomeyeapi/zoomeyeapi.go
+++ b/v2/pkg/subscraping/sources/zoomeyeapi/zoomeyeapi.go
@@ -57,11 +57,13 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 			var res zoomeyeResults
 			err = json.NewDecoder(resp.Body).Decode(&res)
+
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 				_ = resp.Body.Close()
 				return
 			}
+			_ = resp.Body.Close()
 			pages = int(res.Total/1000) + 1
 			for _, r := range res.List {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: r.Name}

--- a/v2/pkg/subscraping/sources/zoomeyeapi/zoomeyeapi.go
+++ b/v2/pkg/subscraping/sources/zoomeyeapi/zoomeyeapi.go
@@ -1,0 +1,80 @@
+package zoomeyeapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+)
+
+//type loginResp struct {
+//	JWT string `json:"access_token"`
+//}
+
+// search results
+type zoomeyeResults struct {
+	Status int `json:"status"`
+	Total  int `json:"total"`
+	List   []struct {
+		Name string   `json:"name"`
+		Ip   []string `json:"ip"`
+	} `json:"list"`
+}
+
+// Source is the passive scraping agent
+type Source struct{}
+
+// Run function returns all subdomains found with the service
+func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
+	results := make(chan subscraping.Result)
+
+	go func() {
+		defer close(results)
+
+		if session.Keys.ZoomEyeKey == "" {
+			return
+		}
+
+		headers := map[string]string{
+			"API-KEY":      session.Keys.ZoomEyeKey,
+			"Accept":       "application/json",
+			"Content-Type": "application/json",
+		}
+		var pages = 1
+		for currentPage := 1; currentPage <= pages; currentPage++ {
+			api := fmt.Sprintf("https://api.zoomeye.org/domain/search?q=%s&type=1&s=1000&page=%d", domain, currentPage)
+			resp, err := session.Get(ctx, api, "", headers)
+			isForbidden := resp != nil && resp.StatusCode == http.StatusForbidden
+			if err != nil {
+				if !isForbidden && currentPage == 0 {
+					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+					session.DiscardHTTPResponse(resp)
+				}
+				return
+			}
+
+			var res zoomeyeResults
+			err = json.NewDecoder(resp.Body).Decode(&res)
+			if err != nil {
+				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+				resp.Body.Close()
+				return
+			}
+			resp.Body.Close()
+			pages = int(res.Total/1000) + 1
+			for _, r := range res.List {
+				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: r.Name}
+			}
+			currentPage++
+		}
+	}()
+
+	return results
+}
+
+// Name returns the name of the source
+func (s *Source) Name() string {
+	return "zoomeyeapi"
+}

--- a/v2/pkg/subscraping/sources/zoomeyeapi/zoomeyeapi.go
+++ b/v2/pkg/subscraping/sources/zoomeyeapi/zoomeyeapi.go
@@ -9,10 +9,6 @@ import (
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 )
 
-//type loginResp struct {
-//	JWT string `json:"access_token"`
-//}
-
 // search results
 type zoomeyeResults struct {
 	Status int `json:"status"`
@@ -48,7 +44,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			resp, err := session.Get(ctx, api, "", headers)
 			isForbidden := resp != nil && resp.StatusCode == http.StatusForbidden
 			if err != nil {
-				if !isForbidden && currentPage == 0 {
+				if !isForbidden {
 					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 					session.DiscardHTTPResponse(resp)
 				}

--- a/v2/pkg/subscraping/types.go
+++ b/v2/pkg/subscraping/types.go
@@ -61,6 +61,7 @@ type Keys struct {
 	Virustotal           string   `json:"virustotal"`
 	ZoomEyeUsername      string   `json:"zoomeye_username"`
 	ZoomEyePassword      string   `json:"zoomeye_password"`
+	ZoomEyeKey           string   `json:"zoomeye_key"`
 	FofaUsername         string   `json:"fofa_username"`
 	FofaSecret           string   `json:"fofa_secret"`
 }


### PR DESCRIPTION
Use new api(https://api.zoomeye.org/domain/search) instead of zoomeye search.

It can find more subdomains than zoomeye search.this api is free, fast and no limit

Need to get apikey on this page: https://www.zoomeye.org/profile/info

Set "zoomeyekey" in config.yaml:

```
zoomeyeapi:
    - c659bb1e-0000-00000-0000-c9643450fee7
```

example:
subfinder -d shein.com -sources [source]

zoomeyeapi
`Found 74 subdomains for shein.com in 3 seconds 211 milliseconds`

zoomeye
`Found 40 subdomains for shein.com in 47 seconds 396 milliseconds`





