### PR TITLE
Add support for Bufferover non-commercial API keys.

### DIFF
--- a/v2/pkg/runner/config.go
+++ b/v2/pkg/runner/config.go
@@ -29,6 +29,7 @@ type ConfigFile struct {
 	// ExcludeSources contains the sources to not include in the enumeration process
 	ExcludeSources []string `yaml:"exclude-sources,omitempty"`
 	// API keys for different sources
+	Bufferover     []string `yaml:"bufferover"`
 	Binaryedge     []string `yaml:"binaryedge"`
 	Censys         []string `yaml:"censys"`
 	Certspotter    []string `yaml:"certspotter"`
@@ -120,6 +121,10 @@ func (c *ConfigFile) GetKeys() subscraping.Keys {
 
 	if len(c.Binaryedge) > 0 {
 		keys.Binaryedge = c.Binaryedge[rand.Intn(len(c.Binaryedge))]
+	}
+
+	if len(c.Bufferover) > 0 {
+		keys.Bufferover = c.Bufferover[rand.Intn(len(c.Bufferover))]
 	}
 
 	if len(c.Censys) > 0 {

--- a/v2/pkg/subscraping/sources/bufferover/bufferover.go
+++ b/v2/pkg/subscraping/sources/bufferover/bufferover.go
@@ -28,18 +28,25 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	results := make(chan subscraping.Result)
 
 	go func() {
-		// Run enumeration on subdomain dataset for historical SONAR datasets
-		s.getData(ctx, fmt.Sprintf("https://dns.bufferover.run/dns?q=.%s", domain), session, results)
-		s.getData(ctx, fmt.Sprintf("https://tls.bufferover.run/dns?q=.%s", domain), session, results)
+		defer close(results)
 
-		close(results)
+		// DNS data does not rely on an API key.
+		s.getData(ctx, fmt.Sprintf("https://dns.bufferover.run/dns?q=.%s", domain), "", session, results)
+
+		if session.Keys.Bufferover == "" {
+			return
+		}
+
+		// TLS data relies on an API key.
+		s.getData(ctx, fmt.Sprintf("https://tls.bufferover.run/dns?q=.%s", domain), session.Keys.Bufferover, session, results)
 	}()
 
 	return results
 }
 
-func (s *Source) getData(ctx context.Context, sourceURL string, session *subscraping.Session, results chan subscraping.Result) {
-	resp, err := session.SimpleGet(ctx, sourceURL)
+func (s *Source) getData(ctx context.Context, sourceURL string, apiKey string, session *subscraping.Session, results chan subscraping.Result) {
+	resp, err := session.Get(ctx, sourceURL, "", map[string]string{"x-api-key": apiKey})
+
 	if err != nil && resp == nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 		session.DiscardHTTPResponse(resp)

--- a/v2/pkg/subscraping/types.go
+++ b/v2/pkg/subscraping/types.go
@@ -40,6 +40,7 @@ type Session struct {
 // Keys contains the current API Keys we have in store
 type Keys struct {
 	Binaryedge           string   `json:"binaryedge"`
+	Bufferover           string   `json:"bufferover"`
 	CensysToken          string   `json:"censysUsername"`
 	CensysSecret         string   `json:"censysPassword"`
 	Certspotter          string   `json:"certspotter"`


### PR DESCRIPTION
This PR adds support for Bufferover's new API keys, which are [now required](https://blog.erbbysam.com/index.php/2022/01/15/why-i-broke-your-subdomain-recon-pipeline-last-night/) for `tls.bufferover.run`. This data source is very useful and is one of the largest data sources I see come out of Subfinder in my automation.

Unfortunately, this API was split into two API hosts, with two different types of API keys. It's not clear that it's easy to add support for the commercial API into Subfinder, as we would probably need two data sources or an explicit toggle. But for now, this is an easy (albeit rate-limited) fix.