### PR TITLE
Update GH API sample with new GH Token format

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ securitytrails: []
 shodan:
   - AAAAClP1bJJSRMEYJazgwhJKrggRwKA
 github:
-  - d23a554bbc1aabb208c9acfbd2dd41ce7fc9db39
-  - asdsd54bbc1aabb208c9acfbd2dd41ce7fc9db39
+  - ghp_lkyJGU3jv1xmwk4SDXavrLDJ4dl2pSJMzj4X
+  - ghp_gkUuhkIYdQPj13ifH4KA3cXRn8JD2lqir2d4
 ```
 
 # Running Subfinder


### PR DESCRIPTION
GH changed its tokens to a formatted way: https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
This will help identify to people to use the personal access tokens for the config.
These tokens are fake ones I created but same length and real ones.