### PR TITLE
Add input field to json output

### DIFF
--- a/v2/pkg/resolve/resolve.go
+++ b/v2/pkg/resolve/resolve.go
@@ -25,8 +25,8 @@ type ResolutionPool struct {
 
 // HostEntry defines a host with the source
 type HostEntry struct {
-	Host   string `json:"host"`
-	Source string `json:"source"`
+	Host   string
+	Source string
 }
 
 // Result contains the result for a host resolution

--- a/v2/pkg/runner/enumerate.go
+++ b/v2/pkg/runner/enumerate.go
@@ -119,15 +119,15 @@ func (r *Runner) EnumerateSingleDomain(ctx context.Context, domain string, outpu
 	var err error
 	for _, w := range outputs {
 		if r.options.HostIP {
-			err = outputter.WriteHostIP(foundResults, w)
+			err = outputter.WriteHostIP(domain, foundResults, w)
 		} else {
 			if r.options.RemoveWildcard {
-				err = outputter.WriteHostNoWildcard(foundResults, w)
+				err = outputter.WriteHostNoWildcard(domain, foundResults, w)
 			} else {
 				if r.options.CaptureSources {
-					err = outputter.WriteSourceHost(sourceMap, w)
+					err = outputter.WriteSourceHost(domain, sourceMap, w)
 				} else {
-					err = outputter.WriteHost(uniqueMap, w)
+					err = outputter.WriteHost(domain, uniqueMap, w)
 				}
 			}
 		}

--- a/v2/pkg/runner/outputter.go
+++ b/v2/pkg/runner/outputter.go
@@ -17,13 +17,18 @@ type OutPutter struct {
 	JSON bool
 }
 
-type jsonResult struct {
+type jsonSourceResult struct {
+	Host   string `json:"host"`
+	Source string `json:"source"`
+}
+
+type jsonSourceIPResult struct {
 	Host   string `json:"host"`
 	IP     string `json:"ip"`
 	Source string `json:"source"`
 }
 
-type jsonSourceResult struct {
+type jsonSourcesResult struct {
 	Host    string   `json:"host"`
 	Sources []string `json:"sources"`
 }
@@ -99,7 +104,7 @@ func writePlainHostIP(results map[string]resolve.Result, writer io.Writer) error
 func writeJSONHostIP(results map[string]resolve.Result, writer io.Writer) error {
 	encoder := jsoniter.NewEncoder(writer)
 
-	var data jsonResult
+	var data jsonSourceIPResult
 
 	for _, result := range results {
 		data.Host = result.Host
@@ -156,8 +161,11 @@ func writePlainHost(results map[string]resolve.HostEntry, writer io.Writer) erro
 func writeJSONHost(results map[string]resolve.HostEntry, writer io.Writer) error {
 	encoder := jsoniter.NewEncoder(writer)
 
+	var data jsonSourceResult
 	for _, result := range results {
-		err := encoder.Encode(result)
+		data.Host = result.Host
+		data.Source = result.Source
+		err := encoder.Encode(data)
 		if err != nil {
 			return err
 		}
@@ -179,7 +187,7 @@ func (o *OutPutter) WriteSourceHost(sourceMap map[string]map[string]struct{}, wr
 func writeSourceJSONHost(sourceMap map[string]map[string]struct{}, writer io.Writer) error {
 	encoder := jsoniter.NewEncoder(writer)
 
-	var data jsonSourceResult
+	var data jsonSourcesResult
 
 	for host, sources := range sourceMap {
 		data.Host = host


### PR DESCRIPTION
This PR implements feature request #519
- In the first commit, I moved all JSON types into one place - removed JSON tags from `resolve.HostEntry` and add a new type `jsonSourceResult`. This is necessary to keep all the JSON output in one place.
- In the second commit I added `Input` type to all `json*` result types. As a simple solution, I decided to pass the `input` domain as a separate argument to all outputter functions.