### PR TITLE
Added User-Agent for BeVigil

### DIFF
--- a/v2/pkg/subscraping/sources/bevigil/bevigil.go
+++ b/v2/pkg/subscraping/sources/bevigil/bevigil.go
@@ -31,7 +31,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 		getUrl := fmt.Sprintf("https://osint.bevigil.com/api/%s/subdomains/", domain)
 
-		resp, err := session.Get(ctx, getUrl, "", map[string]string{"X-Access-Token": randomApiKey})
+		resp, err := session.Get(ctx, getUrl, "", map[string]string{"X-Access-Token": randomApiKey, "User-Agent": "subfinder"})
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)


### PR DESCRIPTION
Some sources/APIs prefer to have a User-Agent that lets them distinguish if a tool being is used to query their APIs.
This helps them see how much usage is through tools. So i added a "User-Agent: subfinder" header.
Some other sources may prefer this too.