### PR TITLE
Fix incorrect assignment of recursive sources

### DIFF
--- a/v2/pkg/runner/banners.go
+++ b/v2/pkg/runner/banners.go
@@ -40,7 +40,7 @@ func (options *Options) loadProvidersFrom(location string) {
 	}
 	// todo: move elsewhere
 	if len(options.Resolvers) == 0 {
-		options.Recursive = resolve.DefaultResolvers
+		options.Resolvers = resolve.DefaultResolvers
 	}
 	if len(options.Sources) == 0 {
 		options.Sources = passive.DefaultSources


### PR DESCRIPTION
I was doing some testing and noticed that the command-line `-recursive` option doesn't function as expected. This is due to the variable being set to the default resolvers if the list of resolvers is not explicitly specified. This PR fixes this incorrect assignment.

Testing without fix:

```
$ subfinder -recursive -d projectdiscovery.io
...
[INF] Enumerating subdomains for projectdiscovery.io
[INF] Found 0 subdomains for projectdiscovery.io in 61 microseconds
```

Testing with fix:

```
./subfinder -recursive -d projectdiscovery.io
...
[INF] Enumerating subdomains for projectdiscovery.io
cdn.projectdiscovery.io
www.projectdiscovery.io
nuclei.projectdiscovery.io
chaos.projectdiscovery.io
blog.projectdiscovery.io
dns.projectdiscovery.io
pdtm.projectdiscovery.io
nexus.projectdiscovery.io
careers.projectdiscovery.io
apollo.projectdiscovery.io
[INF] Found 10 subdomains for projectdiscovery.io in 1 second 525 milliseconds
```