### PR TITLE
Fix crtsh email values

### DIFF
--- a/v2/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/v2/pkg/subscraping/sources/crtsh/crtsh.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"regexp"
 	"strings"
 
 	jsoniter "github.com/json-iterator/go"
@@ -31,7 +30,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	go func() {
 		defer close(results)
 
-		count := s.getSubdomainsFromSQL(domain, session.Extractor, results)
+		count := s.getSubdomainsFromSQL(domain, session, results)
 		if count > 0 {
 			return
 		}
@@ -41,7 +40,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	return results
 }
 
-func (s *Source) getSubdomainsFromSQL(domain string, subDomainExtractor *regexp.Regexp, results chan subscraping.Result) int {
+func (s *Source) getSubdomainsFromSQL(domain string, session *subscraping.Session, results chan subscraping.Result) int {
 	db, err := sql.Open("postgres", "host=crt.sh user=guest dbname=certwatch sslmode=disable binary_parameters=yes")
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
@@ -74,7 +73,7 @@ func (s *Source) getSubdomainsFromSQL(domain string, subDomainExtractor *regexp.
 			return count
 		}
 		count++
-		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subDomainExtractor.FindString(data)}
+		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: session.Extractor.FindString(data)}
 	}
 	return count
 }


### PR DESCRIPTION
Fixes #675, crsth can return email values for specific domains so we always try to extract the subdomain using the default regular expression of the session.