### PR TITLE
CommonCrawl dynamic year range

### DIFF
--- a/v2/pkg/subscraping/sources/commoncrawl/commoncrawl.go
+++ b/v2/pkg/subscraping/sources/commoncrawl/commoncrawl.go
@@ -6,14 +6,21 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 )
 
-const indexURL = "https://index.commoncrawl.org/collinfo.json"
+const (
+	indexURL     = "https://index.commoncrawl.org/collinfo.json"
+	maxYearsBack = 5
+)
+
+var year = time.Now().Year()
 
 type indexResponse struct {
 	ID     string `json:"id"`
@@ -22,8 +29,6 @@ type indexResponse struct {
 
 // Source is the passive scraping agent
 type Source struct{}
-
-var years = [...]string{"2020", "2019", "2018", "2017"}
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
@@ -47,6 +52,11 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 		resp.Body.Close()
+
+		years := make([]string, 0)
+		for i := 0; i < maxYearsBack; i++ {
+			years = append(years, strconv.Itoa(year-i))
+		}
 
 		searchIndexes := make(map[string]string)
 		for _, year := range years {


### PR DESCRIPTION
Dynamic year range starting from the current year and going back five years.

This was done manually on #254 in the past.

Having very old years causes context deadline exceeded errors.