### PR TITLE
feat: surface the duration and error metrics for each source when enumerating domains

### DIFF
--- a/v2/pkg/passive/passive.go
+++ b/v2/pkg/passive/passive.go
@@ -18,7 +18,9 @@ func (a *Agent) EnumerateSubdomains(domain string, proxy string, rateLimit, time
 
 		session, err := subscraping.NewSession(domain, proxy, rateLimit, timeout)
 		if err != nil {
-			results <- subscraping.Result{Type: subscraping.Error, Error: fmt.Errorf("could not init passive session for %s: %s", domain, err)}
+			results <- subscraping.Result{
+				Type: subscraping.Error, Error: fmt.Errorf("could not init passive session for %s: %s", domain, err),
+			}
 			return
 		}
 
@@ -34,11 +36,12 @@ func (a *Agent) EnumerateSubdomains(domain string, proxy string, rateLimit, time
 
 			now := time.Now()
 			go func(source subscraping.Source) {
+				duration := time.Since(now)
 				for resp := range source.Run(ctx, domain, session) {
+					resp.TimeTaken = duration
 					results <- resp
 				}
 
-				duration := time.Since(now)
 				timeTakenMutex.Lock()
 				timeTaken[source.Name()] = fmt.Sprintf("Source took %s for enumeration\n", duration)
 				timeTakenMutex.Unlock()

--- a/v2/pkg/passive/passive.go
+++ b/v2/pkg/passive/passive.go
@@ -34,16 +34,13 @@ func (a *Agent) EnumerateSubdomains(domain string, proxy string, rateLimit, time
 		for _, runner := range a.sources {
 			wg.Add(1)
 
-			now := time.Now()
 			go func(source subscraping.Source) {
-				duration := time.Since(now)
 				for resp := range source.Run(ctx, domain, session) {
-					resp.TimeTaken = duration
 					results <- resp
 				}
 
 				timeTakenMutex.Lock()
-				timeTaken[source.Name()] = fmt.Sprintf("Source took %s for enumeration\n", duration)
+				timeTaken[source.Name()] = fmt.Sprintf("Source took %s for enumeration\n", source.TimeTaken())
 				timeTakenMutex.Unlock()
 
 				wg.Done()

--- a/v2/pkg/passive/sources_wo_auth_test.go
+++ b/v2/pkg/passive/sources_wo_auth_test.go
@@ -31,6 +31,10 @@ func TestSourcesWithoutKeys(t *testing.T) {
 			continue
 		}
 
+		if source.Name() == "commoncrawl" {
+			continue // commoncrawl is under resourced and will likely time-out so step over it for this test https://groups.google.com/u/2/g/common-crawl/c/3QmQjFA_3y4/m/vTbhGqIBBQAJ
+		}
+
 		t.Run(source.Name(), func(t *testing.T) {
 			var results []subscraping.Result
 

--- a/v2/pkg/runner/enumerate.go
+++ b/v2/pkg/runner/enumerate.go
@@ -148,6 +148,11 @@ func (r *Runner) EnumerateSingleDomain(domain string, writers []io.Writer) error
 	}
 	gologger.Info().Msgf("Found %d subdomains for '%s' in %s\n", numberOfSubDomains, domain, duration)
 
+	if r.options.Statistics {
+		gologger.Info().Msgf("Printing source statistics for '%s'", domain)
+		printStatistics(r.passiveAgent.GetStatistics())
+	}
+
 	return nil
 }
 

--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -41,6 +41,7 @@ type Options struct {
 	Version            bool                // Version specifies if we should just show version and exit
 	OnlyRecursive      bool                // Recursive specifies whether to use only recursive subdomain enumeration sources
 	All                bool                // All specifies whether to use all (slow) sources.
+	Statistics         bool                // Statistics specifies whether to report source statistics
 	Threads            int                 // Threads controls the number of threads to use for active enumerations
 	Timeout            int                 // Timeout is the seconds to wait for sources to respond
 	MaxEnumerationTime int                 // MaxEnumerationTime is the maximum amount of time in minutes to wait for enumeration
@@ -137,6 +138,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.Verbose, "v", false, "show verbose output"),
 		flagSet.BoolVarP(&options.NoColor, "no-color", "nc", false, "disable color in output"),
 		flagSet.BoolVarP(&options.ListSources, "list-sources", "ls", false, "list all available sources"),
+		flagSet.BoolVar(&options.Statistics, "stats", false, "report source statistics"),
 	)
 
 	createGroup(flagSet, "optimization", "Optimization",

--- a/v2/pkg/runner/stats.go
+++ b/v2/pkg/runner/stats.go
@@ -1,0 +1,41 @@
+package runner
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+	"golang.org/x/exp/maps"
+)
+
+func printStatistics(stats map[string]subscraping.Statistics) {
+
+	sources := maps.Keys(stats)
+	sort.Strings(sources)
+
+	var lines []string
+	var skipped []string
+
+	for _, source := range sources {
+		sourceStats := stats[source]
+		if sourceStats.Skipped {
+			skipped = append(skipped, fmt.Sprintf(" %s", source))
+		} else {
+			lines = append(lines, fmt.Sprintf(" %-20s %-10s %10d %10d", source, sourceStats.TimeTaken.Round(time.Millisecond).String(), sourceStats.Results, sourceStats.Errors))
+		}
+	}
+
+	if len(lines) > 0 {
+		fmt.Printf("\n Source               Duration      Results     Errors\n%s\n", strings.Repeat("─", 56))
+		fmt.Print(strings.Join(lines, "\n"))
+		fmt.Print("\n")
+	}
+
+	if len(skipped) > 0 {
+		fmt.Printf("\n The following sources were included but skipped...\n\n")
+		fmt.Print(strings.Join(skipped, "\n"))
+		fmt.Print("\n\n")
+	}
+}

--- a/v2/pkg/runner/stats.go
+++ b/v2/pkg/runner/stats.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 	"golang.org/x/exp/maps"
 )
@@ -28,14 +29,14 @@ func printStatistics(stats map[string]subscraping.Statistics) {
 	}
 
 	if len(lines) > 0 {
-		fmt.Printf("\n Source               Duration      Results     Errors\n%s\n", strings.Repeat("─", 56))
-		fmt.Print(strings.Join(lines, "\n"))
-		fmt.Print("\n")
+		gologger.Print().Msgf("\n Source               Duration      Results     Errors\n%s\n", strings.Repeat("─", 56))
+		gologger.Print().Msgf(strings.Join(lines, "\n"))
+		gologger.Print().Msgf("\n")
 	}
 
 	if len(skipped) > 0 {
-		fmt.Printf("\n The following sources were included but skipped...\n\n")
-		fmt.Print(strings.Join(skipped, "\n"))
-		fmt.Print("\n\n")
+		gologger.Print().Msgf("\n The following sources were included but skipped...\n\n")
+		gologger.Print().Msgf(strings.Join(skipped, "\n"))
+		gologger.Print().Msgf("\n\n")
 	}
 }

--- a/v2/pkg/subscraping/sources/alienvault/alienvault.go
+++ b/v2/pkg/subscraping/sources/alienvault/alienvault.go
@@ -21,19 +21,26 @@ type alienvaultResponse struct {
 // Source is the passive scraping agent
 type Source struct {
 	timeTaken time.Duration
+	results   int
+	errors    int
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://otx.alienvault.com/api/v1/indicators/domain/%s/passive_dns", domain))
 		if err != nil && resp == nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -43,6 +50,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		err = json.NewDecoder(resp.Body).Decode(&response)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			resp.Body.Close()
 			return
 		}
@@ -57,8 +65,8 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 		for _, record := range response.PassiveDNS {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: record.Hostname}
+			s.results++
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -85,6 +93,10 @@ func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
 }

--- a/v2/pkg/subscraping/sources/anubis/anubis.go
+++ b/v2/pkg/subscraping/sources/anubis/anubis.go
@@ -4,6 +4,7 @@ package anubis
 import (
 	"context"
 	"fmt"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -11,11 +12,14 @@ import (
 )
 
 // Source is the passive scraping agent
-type Source struct{}
+type Source struct {
+	timeTaken time.Duration
+}
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -40,6 +44,8 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		for _, record := range subdomains {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: record}
 		}
+
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -64,4 +70,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/anubis/anubis.go
+++ b/v2/pkg/subscraping/sources/anubis/anubis.go
@@ -14,19 +14,26 @@ import (
 // Source is the passive scraping agent
 type Source struct {
 	timeTaken time.Duration
+	errors    int
+	results   int
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://jonlu.ca/anubis/subdomains/%s", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -35,6 +42,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		err = jsoniter.NewDecoder(resp.Body).Decode(&subdomains)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			resp.Body.Close()
 			return
 		}
@@ -43,9 +51,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 		for _, record := range subdomains {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: record}
+			s.results++
 		}
 
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -72,6 +80,10 @@ func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
 }

--- a/v2/pkg/subscraping/sources/bevigil/bevigil.go
+++ b/v2/pkg/subscraping/sources/bevigil/bevigil.go
@@ -4,6 +4,7 @@ package bevigil
 import (
 	"context"
 	"fmt"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -16,11 +17,14 @@ type Response struct {
 }
 
 type Source struct {
-	apiKeys []string
+	apiKeys   []string
+	timeTaken time.Duration
 }
 
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
+
 	go func() {
 		defer close(results)
 
@@ -31,7 +35,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 		getUrl := fmt.Sprintf("https://osint.bevigil.com/api/%s/subdomains/", domain)
 
-		resp, err := session.Get(ctx, getUrl, "", map[string]string{"X-Access-Token": randomApiKey, "User-Agent": "subfinder"})
+		resp, err := session.Get(ctx, getUrl, "", map[string]string{
+			"X-Access-Token": randomApiKey, "User-Agent": "subfinder",
+		})
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			session.DiscardHTTPResponse(resp)
@@ -56,8 +62,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		for _, subdomain := range subdomains {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 		}
-	}()
 
+		s.timeTaken = time.Since(startTime)
+	}()
 	return results
 }
 
@@ -79,4 +86,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/bevigil/bevigil.go
+++ b/v2/pkg/subscraping/sources/bevigil/bevigil.go
@@ -19,17 +19,25 @@ type Response struct {
 type Source struct {
 	apiKeys   []string
 	timeTaken time.Duration
+	errors    int
+	results   int
+	skipped   bool
 }
 
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		randomApiKey := subscraping.PickRandom(s.apiKeys, s.Name())
 		if randomApiKey == "" {
+			s.skipped = true
 			return
 		}
 
@@ -63,7 +71,6 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 		}
 
-		s.timeTaken = time.Since(startTime)
 	}()
 	return results
 }
@@ -88,6 +95,11 @@ func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+		Skipped:   s.skipped,
+	}
 }

--- a/v2/pkg/subscraping/sources/bufferover/bufferover.go
+++ b/v2/pkg/subscraping/sources/bufferover/bufferover.go
@@ -25,23 +25,30 @@ type response struct {
 type Source struct {
 	apiKeys   []string
 	timeTaken time.Duration
+	errors    int
+	results   int
+	skipped   bool
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		randomApiKey := subscraping.PickRandom(s.apiKeys, s.Name())
 		if randomApiKey == "" {
+			s.skipped = true
 			return
 		}
 
 		s.getData(ctx, fmt.Sprintf("https://tls.bufferover.run/dns?q=.%s", domain), randomApiKey, session, results)
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -52,6 +59,7 @@ func (s *Source) getData(ctx context.Context, sourceURL string, apiKey string, s
 
 	if err != nil && resp == nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+		s.errors++
 		session.DiscardHTTPResponse(resp)
 		return
 	}
@@ -60,6 +68,7 @@ func (s *Source) getData(ctx context.Context, sourceURL string, apiKey string, s
 	err = jsoniter.NewDecoder(resp.Body).Decode(&bufforesponse)
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+		s.errors++
 		resp.Body.Close()
 		return
 	}
@@ -72,6 +81,7 @@ func (s *Source) getData(ctx context.Context, sourceURL string, apiKey string, s
 		results <- subscraping.Result{
 			Source: s.Name(), Type: subscraping.Error, Error: fmt.Errorf("%s", strings.Join(metaErrors, ", ")),
 		}
+		s.errors++
 		return
 	}
 
@@ -88,6 +98,7 @@ func (s *Source) getData(ctx context.Context, sourceURL string, apiKey string, s
 		for _, value := range session.Extractor.FindAllString(subdomain, -1) {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: value}
 		}
+		s.results++
 	}
 }
 
@@ -112,6 +123,11 @@ func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+		Skipped:   s.skipped,
+	}
 }

--- a/v2/pkg/subscraping/sources/c99/c99.go
+++ b/v2/pkg/subscraping/sources/c99/c99.go
@@ -16,6 +16,9 @@ import (
 type Source struct {
 	apiKeys   []string
 	timeTaken time.Duration
+	errors    int
+	results   int
+	skipped   bool
 }
 
 type dnsdbLookupResponse struct {
@@ -31,13 +34,18 @@ type dnsdbLookupResponse struct {
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		randomApiKey := subscraping.PickRandom(s.apiKeys, s.Name())
 		if randomApiKey == "" {
+			s.skipped = true
 			return
 		}
 
@@ -54,6 +62,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		err = jsoniter.NewDecoder(resp.Body).Decode(&response)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			return
 		}
 
@@ -61,15 +70,16 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			results <- subscraping.Result{
 				Source: s.Name(), Type: subscraping.Error, Error: fmt.Errorf("%v", response.Error),
 			}
+			s.errors++
 			return
 		}
 
 		for _, data := range response.Subdomains {
 			if !strings.HasPrefix(data.Subdomain, ".") {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: data.Subdomain}
+				s.results++
 			}
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -96,6 +106,11 @@ func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+		Skipped:   s.skipped,
+	}
 }

--- a/v2/pkg/subscraping/sources/censys/censys.go
+++ b/v2/pkg/subscraping/sources/censys/censys.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"strconv"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -27,7 +28,8 @@ type response struct {
 
 // Source is the passive scraping agent
 type Source struct {
-	apiKeys []apiKey
+	apiKeys   []apiKey
+	timeTaken time.Duration
 }
 
 type apiKey struct {
@@ -38,6 +40,7 @@ type apiKey struct {
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -93,6 +96,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 			currentPage++
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -119,4 +123,8 @@ func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = subscraping.CreateApiKeys(keys, func(k, v string) apiKey {
 		return apiKey{k, v}
 	})
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/certspotter/certspotter.go
+++ b/v2/pkg/subscraping/sources/certspotter/certspotter.go
@@ -4,6 +4,7 @@ package certspotter
 import (
 	"context"
 	"fmt"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -17,12 +18,14 @@ type certspotterObject struct {
 
 // Source is the passive scraping agent
 type Source struct {
-	apiKeys []string
+	apiKeys   []string
+	timeTaken time.Duration
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -93,6 +96,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 			id = response[len(response)-1].ID
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -117,4 +121,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/certspotter/certspotter.go
+++ b/v2/pkg/subscraping/sources/certspotter/certspotter.go
@@ -20,18 +20,26 @@ type certspotterObject struct {
 type Source struct {
 	apiKeys   []string
 	timeTaken time.Duration
+	errors    int
+	results   int
+	skipped   bool
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		randomApiKey := subscraping.PickRandom(s.apiKeys, s.Name())
 		if randomApiKey == "" {
+			s.skipped = true
 			return
 		}
 
@@ -41,6 +49,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.Get(ctx, fmt.Sprintf("https://api.certspotter.com/v1/issuances?domain=%s&include_subdomains=true&expand=dns_names", domain), cookies, headers)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -49,6 +58,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		err = jsoniter.NewDecoder(resp.Body).Decode(&response)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			resp.Body.Close()
 			return
 		}
@@ -57,6 +67,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		for _, cert := range response {
 			for _, subdomain := range cert.DNSNames {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+				s.results++
 			}
 		}
 
@@ -72,6 +83,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			resp, err := session.Get(ctx, reqURL, cookies, headers)
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+				s.errors++
 				return
 			}
 
@@ -79,6 +91,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			err = jsoniter.NewDecoder(resp.Body).Decode(&response)
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+				s.errors++
 				resp.Body.Close()
 				return
 			}
@@ -91,12 +104,12 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			for _, cert := range response {
 				for _, subdomain := range cert.DNSNames {
 					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+					s.results++
 				}
 			}
 
 			id = response[len(response)-1].ID
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -123,6 +136,11 @@ func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+		Skipped:   s.skipped,
+	}
 }

--- a/v2/pkg/subscraping/sources/chinaz/chinaz.go
+++ b/v2/pkg/subscraping/sources/chinaz/chinaz.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -13,12 +14,14 @@ import (
 
 // Source is the passive scraping agent
 type Source struct {
-	apiKeys []string
+	apiKeys   []string
+	timeTaken time.Duration
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -51,6 +54,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			return
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -75,4 +79,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/commoncrawl/commoncrawl.go
+++ b/v2/pkg/subscraping/sources/commoncrawl/commoncrawl.go
@@ -28,11 +28,14 @@ type indexResponse struct {
 }
 
 // Source is the passive scraping agent
-type Source struct{}
+type Source struct {
+	timeTaken time.Duration
+}
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -76,6 +79,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				break
 			}
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -100,6 +104,10 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }
 
 func (s *Source) getSubdomains(ctx context.Context, searchURL, domain string, session *subscraping.Session, results chan subscraping.Result) bool {

--- a/v2/pkg/subscraping/sources/commoncrawl/commoncrawl.go
+++ b/v2/pkg/subscraping/sources/commoncrawl/commoncrawl.go
@@ -30,19 +30,26 @@ type indexResponse struct {
 // Source is the passive scraping agent
 type Source struct {
 	timeTaken time.Duration
+	errors    int
+	results   int
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		resp, err := session.SimpleGet(ctx, indexURL)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -51,6 +58,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		err = jsoniter.NewDecoder(resp.Body).Decode(&indexes)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			resp.Body.Close()
 			return
 		}
@@ -79,7 +87,6 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				break
 			}
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -106,8 +113,12 @@ func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
 }
 
 func (s *Source) getSubdomains(ctx context.Context, searchURL, domain string, session *subscraping.Session, results chan subscraping.Result) bool {

--- a/v2/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/v2/pkg/subscraping/sources/crtsh/crtsh.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -21,11 +22,14 @@ type subdomain struct {
 }
 
 // Source is the passive scraping agent
-type Source struct{}
+type Source struct {
+	timeTaken time.Duration
+}
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -35,6 +39,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 		_ = s.getSubdomainsFromHTTP(ctx, domain, session, results)
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -155,4 +160,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/v2/pkg/subscraping/sources/crtsh/crtsh.go
@@ -24,22 +24,27 @@ type subdomain struct {
 // Source is the passive scraping agent
 type Source struct {
 	timeTaken time.Duration
+	errors    int
+	results   int
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		count := s.getSubdomainsFromSQL(domain, session, results)
 		if count > 0 {
 			return
 		}
 		_ = s.getSubdomainsFromHTTP(ctx, domain, session, results)
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -49,6 +54,7 @@ func (s *Source) getSubdomainsFromSQL(domain string, session *subscraping.Sessio
 	db, err := sql.Open("postgres", "host=crt.sh user=guest dbname=certwatch sslmode=disable binary_parameters=yes")
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+		s.errors++
 		return 0
 	}
 
@@ -83,10 +89,12 @@ func (s *Source) getSubdomainsFromSQL(domain string, session *subscraping.Sessio
 	rows, err := db.Query(query, domain)
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+		s.errors++
 		return 0
 	}
 	if err := rows.Err(); err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+		s.errors++
 		return 0
 	}
 
@@ -97,6 +105,7 @@ func (s *Source) getSubdomainsFromSQL(domain string, session *subscraping.Sessio
 		err := rows.Scan(&data)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			return count
 		}
 
@@ -105,6 +114,7 @@ func (s *Source) getSubdomainsFromSQL(domain string, session *subscraping.Sessio
 			value := session.Extractor.FindString(subdomain)
 			if value != "" {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: value}
+				s.results++
 			}
 		}
 	}
@@ -115,6 +125,7 @@ func (s *Source) getSubdomainsFromHTTP(ctx context.Context, domain string, sessi
 	resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://crt.sh/?q=%%25.%s&output=json", domain))
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+		s.errors++
 		session.DiscardHTTPResponse(resp)
 		return false
 	}
@@ -123,6 +134,7 @@ func (s *Source) getSubdomainsFromHTTP(ctx context.Context, domain string, sessi
 	err = jsoniter.NewDecoder(resp.Body).Decode(&subdomains)
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+		s.errors++
 		resp.Body.Close()
 		return false
 	}
@@ -135,6 +147,7 @@ func (s *Source) getSubdomainsFromHTTP(ctx context.Context, domain string, sessi
 			if value != "" {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: value}
 			}
+			s.results++
 		}
 	}
 
@@ -162,6 +175,10 @@ func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
 }

--- a/v2/pkg/subscraping/sources/digitorus/digitorus.go
+++ b/v2/pkg/subscraping/sources/digitorus/digitorus.go
@@ -14,19 +14,26 @@ import (
 // Source is the passive scraping agent
 type Source struct {
 	timeTaken time.Duration
+	errors    int
+	results   int
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://certificatedetails.com/%s", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -44,9 +51,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				results <- subscraping.Result{
 					Source: s.Name(), Type: subscraping.Subdomain, Value: strings.TrimPrefix(subdomain, "."),
 				}
+				s.results++
 			}
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -73,6 +80,10 @@ func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
 }

--- a/v2/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/v2/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 )
@@ -59,11 +60,14 @@ func postForm(ctx context.Context, session *subscraping.Session, token, domain s
 }
 
 // Source is the passive scraping agent
-type Source struct{}
+type Source struct {
+	timeTaken time.Duration
+}
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -93,6 +97,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		for _, subdomain := range session.Extractor.FindAllString(data, -1) {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -117,4 +122,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/v2/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -62,19 +62,27 @@ func postForm(ctx context.Context, session *subscraping.Session, token, domain s
 // Source is the passive scraping agent
 type Source struct {
 	timeTaken time.Duration
+	errors    int
+	results   int
+	skipped   bool
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		resp, err := session.SimpleGet(ctx, "https://dnsdumpster.com/")
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -82,6 +90,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			resp.Body.Close()
 			return
 		}
@@ -91,13 +100,14 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		data, err := postForm(ctx, session, csrfToken, domain)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			return
 		}
 
 		for _, subdomain := range session.Extractor.FindAllString(data, -1) {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+			s.results++
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -124,6 +134,10 @@ func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
 }

--- a/v2/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/v2/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -64,7 +64,6 @@ type Source struct {
 	timeTaken time.Duration
 	errors    int
 	results   int
-	skipped   bool
 }
 
 // Run function returns all subdomains found with the service

--- a/v2/pkg/subscraping/sources/fofa/fofa.go
+++ b/v2/pkg/subscraping/sources/fofa/fofa.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -21,7 +22,8 @@ type fofaResponse struct {
 
 // Source is the passive scraping agent
 type Source struct {
-	apiKeys []apiKey
+	apiKeys   []apiKey
+	timeTaken time.Duration
 }
 
 type apiKey struct {
@@ -32,6 +34,7 @@ type apiKey struct {
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -60,7 +63,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp.Body.Close()
 
 		if response.Error {
-			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: fmt.Errorf("%s", response.ErrMsg)}
+			results <- subscraping.Result{
+				Source: s.Name(), Type: subscraping.Error, Error: fmt.Errorf("%s", response.ErrMsg),
+			}
 			return
 		}
 
@@ -72,6 +77,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 			}
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -98,4 +104,8 @@ func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = subscraping.CreateApiKeys(keys, func(k, v string) apiKey {
 		return apiKey{k, v}
 	})
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/fofa/fofa.go
+++ b/v2/pkg/subscraping/sources/fofa/fofa.go
@@ -24,6 +24,9 @@ type fofaResponse struct {
 type Source struct {
 	apiKeys   []apiKey
 	timeTaken time.Duration
+	errors    int
+	results   int
+	skipped   bool
 }
 
 type apiKey struct {
@@ -34,13 +37,18 @@ type apiKey struct {
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		randomApiKey := subscraping.PickRandom(s.apiKeys, s.Name())
 		if randomApiKey.username == "" || randomApiKey.secret == "" {
+			s.skipped = true
 			return
 		}
 
@@ -49,6 +57,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://fofa.info/api/v1/search/all?full=true&fields=host&page=1&size=10000&email=%s&key=%s&qbase64=%s", randomApiKey.username, randomApiKey.secret, qbase64))
 		if err != nil && resp == nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -57,6 +66,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		err = jsoniter.NewDecoder(resp.Body).Decode(&response)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			resp.Body.Close()
 			return
 		}
@@ -66,6 +76,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			results <- subscraping.Result{
 				Source: s.Name(), Type: subscraping.Error, Error: fmt.Errorf("%s", response.ErrMsg),
 			}
+			s.errors++
 			return
 		}
 
@@ -75,9 +86,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 					subdomain = subdomain[strings.Index(subdomain, "//")+2:]
 				}
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+				s.results++
 			}
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -106,6 +117,11 @@ func (s *Source) AddApiKeys(keys []string) {
 	})
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+		Skipped:   s.skipped,
+	}
 }

--- a/v2/pkg/subscraping/sources/fullhunt/fullhunt.go
+++ b/v2/pkg/subscraping/sources/fullhunt/fullhunt.go
@@ -21,23 +21,32 @@ type fullHuntResponse struct {
 type Source struct {
 	apiKeys   []string
 	timeTaken time.Duration
+	errors    int
+	results   int
+	skipped   bool
 }
 
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		randomApiKey := subscraping.PickRandom(s.apiKeys, s.Name())
 		if randomApiKey == "" {
+			s.skipped = true
 			return
 		}
 
 		resp, err := session.Get(ctx, fmt.Sprintf("https://fullhunt.io/api/v1/domain/%s/subdomains", domain), "", map[string]string{"X-API-KEY": randomApiKey})
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -46,14 +55,15 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		err = jsoniter.NewDecoder(resp.Body).Decode(&response)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			resp.Body.Close()
 			return
 		}
 		resp.Body.Close()
 		for _, record := range response.Hosts {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: record}
+			s.results++
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -80,6 +90,11 @@ func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+		Skipped:   s.skipped,
+	}
 }

--- a/v2/pkg/subscraping/sources/hackertarget/hackertarget.go
+++ b/v2/pkg/subscraping/sources/hackertarget/hackertarget.go
@@ -5,16 +5,20 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 )
 
 // Source is the passive scraping agent
-type Source struct{}
+type Source struct {
+	timeTaken time.Duration
+}
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -39,6 +43,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 			}
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -63,4 +68,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/hackertarget/hackertarget.go
+++ b/v2/pkg/subscraping/sources/hackertarget/hackertarget.go
@@ -13,19 +13,26 @@ import (
 // Source is the passive scraping agent
 type Source struct {
 	timeTaken time.Duration
+	errors    int
+	results   int
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("http://api.hackertarget.com/hostsearch/?q=%s", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -41,9 +48,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			match := session.Extractor.FindAllString(line, -1)
 			for _, subdomain := range match {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+				s.results++
 			}
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -70,6 +77,10 @@ func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
 }

--- a/v2/pkg/subscraping/sources/passivetotal/passivetotal.go
+++ b/v2/pkg/subscraping/sources/passivetotal/passivetotal.go
@@ -22,6 +22,9 @@ type response struct {
 type Source struct {
 	apiKeys   []apiKey
 	timeTaken time.Duration
+	errors    int
+	results   int
+	skipped   bool
 }
 
 type apiKey struct {
@@ -32,13 +35,18 @@ type apiKey struct {
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		randomApiKey := subscraping.PickRandom(s.apiKeys, s.Name())
 		if randomApiKey.username == "" || randomApiKey.password == "" {
+			s.skipped = true
 			return
 		}
 
@@ -56,6 +64,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -64,6 +73,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		err = jsoniter.NewDecoder(resp.Body).Decode(&data)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			resp.Body.Close()
 			return
 		}
@@ -76,8 +86,8 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			}
 			finalSubdomain := subdomain + "." + domain
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: finalSubdomain}
+			s.results++
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -106,6 +116,11 @@ func (s *Source) AddApiKeys(keys []string) {
 	})
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+		Skipped:   s.skipped,
+	}
 }

--- a/v2/pkg/subscraping/sources/quake/quake.go
+++ b/v2/pkg/subscraping/sources/quake/quake.go
@@ -34,18 +34,26 @@ type quakeResults struct {
 type Source struct {
 	apiKeys   []string
 	timeTaken time.Duration
+	errors    int
+	results   int
+	skipped   bool
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		randomApiKey := subscraping.PickRandom(s.apiKeys, s.Name())
 		if randomApiKey == "" {
+			s.skipped = true
 			return
 		}
 
@@ -56,6 +64,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		}, bytes.NewReader(requestBody))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -64,6 +73,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		err = jsoniter.NewDecoder(resp.Body).Decode(&response)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			resp.Body.Close()
 			return
 		}
@@ -73,6 +83,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			results <- subscraping.Result{
 				Source: s.Name(), Type: subscraping.Error, Error: fmt.Errorf("%s", response.Message),
 			}
+			s.errors++
 			return
 		}
 
@@ -83,9 +94,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 					subdomain = ""
 				}
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+				s.results++
 			}
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -112,6 +123,11 @@ func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+		Skipped:   s.skipped,
+	}
 }

--- a/v2/pkg/subscraping/sources/rapiddns/rapiddns.go
+++ b/v2/pkg/subscraping/sources/rapiddns/rapiddns.go
@@ -12,19 +12,26 @@ import (
 // Source is the passive scraping agent
 type Source struct {
 	timeTaken time.Duration
+	errors    int
+	results   int
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		resp, err := session.SimpleGet(ctx, "https://rapiddns.io/subdomain/"+domain+"?full=1")
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -32,6 +39,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			resp.Body.Close()
 			return
 		}
@@ -41,8 +49,8 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		src := string(body)
 		for _, subdomain := range session.Extractor.FindAllString(src, -1) {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+			s.results++
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -69,6 +77,10 @@ func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
 }

--- a/v2/pkg/subscraping/sources/rapiddns/rapiddns.go
+++ b/v2/pkg/subscraping/sources/rapiddns/rapiddns.go
@@ -4,16 +4,20 @@ package rapiddns
 import (
 	"context"
 	"io"
+	"time"
 
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 )
 
 // Source is the passive scraping agent
-type Source struct{}
+type Source struct {
+	timeTaken time.Duration
+}
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -38,6 +42,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		for _, subdomain := range session.Extractor.FindAllString(src, -1) {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -62,4 +67,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/reconcloud/reconcloud.go
+++ b/v2/pkg/subscraping/sources/reconcloud/reconcloud.go
@@ -27,19 +27,26 @@ type cloudAssetsList struct {
 // Source is the passive scraping agent
 type Source struct {
 	timeTaken time.Duration
+	errors    int
+	results   int
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://recon.cloud/api/search?domain=%s", domain))
 		if err != nil && resp == nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -48,6 +55,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		err = jsoniter.NewDecoder(resp.Body).Decode(&response)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			resp.Body.Close()
 			return
 		}
@@ -56,9 +64,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		if len(response.CloudAssetsList) > 0 {
 			for _, cloudAsset := range response.CloudAssetsList {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: cloudAsset.Domain}
+				s.results++
 			}
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -85,6 +93,10 @@ func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
 }

--- a/v2/pkg/subscraping/sources/reconcloud/reconcloud.go
+++ b/v2/pkg/subscraping/sources/reconcloud/reconcloud.go
@@ -4,6 +4,7 @@ package reconcloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
@@ -24,11 +25,14 @@ type cloudAssetsList struct {
 }
 
 // Source is the passive scraping agent
-type Source struct{}
+type Source struct {
+	timeTaken time.Duration
+}
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -54,6 +58,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: cloudAsset.Domain}
 			}
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -78,4 +83,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/riddler/riddler.go
+++ b/v2/pkg/subscraping/sources/riddler/riddler.go
@@ -5,16 +5,20 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 )
 
 // Source is the passive scraping agent
-type Source struct{}
+type Source struct {
+	timeTaken time.Duration
+}
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -38,6 +42,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			}
 		}
 		resp.Body.Close()
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -62,4 +67,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/riddler/riddler.go
+++ b/v2/pkg/subscraping/sources/riddler/riddler.go
@@ -13,19 +13,26 @@ import (
 // Source is the passive scraping agent
 type Source struct {
 	timeTaken time.Duration
+	errors    int
+	results   int
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://riddler.io/search?q=pld:%s&view_type=data_table", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -39,10 +46,10 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			subdomain := session.Extractor.FindString(line)
 			if subdomain != "" {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+				s.results++
 			}
 		}
 		resp.Body.Close()
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -69,6 +76,10 @@ func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
 }

--- a/v2/pkg/subscraping/sources/robtex/robtext.go
+++ b/v2/pkg/subscraping/sources/robtex/robtext.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -20,7 +21,8 @@ const (
 
 // Source is the passive scraping agent
 type Source struct {
-	apiKeys []string
+	apiKeys   []string
+	timeTaken time.Duration
 }
 
 type result struct {
@@ -32,6 +34,7 @@ type result struct {
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -61,7 +64,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				}
 			}
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
+
 	return results
 }
 
@@ -113,4 +118,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/securitytrails/securitytrails.go
+++ b/v2/pkg/subscraping/sources/securitytrails/securitytrails.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -17,12 +18,14 @@ type response struct {
 
 // Source is the passive scraping agent
 type Source struct {
-	apiKeys []string
+	apiKeys   []string
+	timeTaken time.Duration
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -58,6 +61,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -82,4 +86,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/sitedossier/sitedossier.go
+++ b/v2/pkg/subscraping/sources/sitedossier/sitedossier.go
@@ -61,11 +61,14 @@ func (a *agent) enumerate(ctx context.Context, baseURL string) {
 }
 
 // Source is the passive scraping agent
-type Source struct{}
+type Source struct {
+	timeTaken time.Duration
+}
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	a := agent{
 		session: session,
@@ -75,6 +78,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	go func() {
 		a.enumerate(ctx, fmt.Sprintf("http://www.sitedossier.com/parentdomain/%s", domain))
 		close(a.results)
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return a.results
@@ -99,4 +103,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/sitedossier/sitedossier.go
+++ b/v2/pkg/subscraping/sources/sitedossier/sitedossier.go
@@ -21,6 +21,7 @@ var reNext = regexp.MustCompile(`<a href="([A-Za-z0-9/.]+)"><b>`)
 
 type agent struct {
 	results chan subscraping.Result
+	errors  int
 	session *subscraping.Session
 }
 
@@ -35,6 +36,7 @@ func (a *agent) enumerate(ctx context.Context, baseURL string) {
 	isnotfound := resp != nil && resp.StatusCode == http.StatusNotFound
 	if err != nil && !isnotfound {
 		a.results <- subscraping.Result{Source: "sitedossier", Type: subscraping.Error, Error: err}
+		a.errors++
 		a.session.DiscardHTTPResponse(resp)
 		return
 	}
@@ -42,6 +44,7 @@ func (a *agent) enumerate(ctx context.Context, baseURL string) {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		a.results <- subscraping.Result{Source: "sitedossier", Type: subscraping.Error, Error: err}
+		a.errors++
 		resp.Body.Close()
 		return
 	}
@@ -63,12 +66,15 @@ func (a *agent) enumerate(ctx context.Context, baseURL string) {
 // Source is the passive scraping agent
 type Source struct {
 	timeTaken time.Duration
+	errors    int
+	results   int
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	a := agent{
 		session: session,
@@ -76,9 +82,14 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 	}
 
 	go func() {
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(a.results)
+		}(time.Now())
+
 		a.enumerate(ctx, fmt.Sprintf("http://www.sitedossier.com/parentdomain/%s", domain))
-		close(a.results)
-		s.timeTaken = time.Since(startTime)
+		s.errors = a.errors
+		s.results = len(a.results)
 	}()
 
 	return a.results
@@ -105,6 +116,10 @@ func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
 }

--- a/v2/pkg/subscraping/sources/threatbook/threatbook.go
+++ b/v2/pkg/subscraping/sources/threatbook/threatbook.go
@@ -28,24 +28,33 @@ type threatBookResponse struct {
 type Source struct {
 	apiKeys   []string
 	timeTaken time.Duration
+	errors    int
+	results   int
+	skipped   bool
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		randomApiKey := subscraping.PickRandom(s.apiKeys, s.Name())
 		if randomApiKey == "" {
+			s.skipped = true
 			return
 		}
 
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://api.threatbook.cn/v3/domain/sub_domains?apikey=%s&resource=%s", randomApiKey, domain))
 		if err != nil && resp == nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -54,6 +63,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		err = jsoniter.NewDecoder(resp.Body).Decode(&response)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			resp.Body.Close()
 			return
 		}
@@ -64,12 +74,14 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				Source: s.Name(), Type: subscraping.Error,
 				Error: fmt.Errorf("code %d, %s", response.ResponseCode, response.VerboseMsg),
 			}
+			s.errors++
 			return
 		}
 
 		total, err := strconv.ParseInt(response.Data.SubDomains.Total, 10, 64)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			return
 		}
 
@@ -78,7 +90,6 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 			}
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -105,6 +116,11 @@ func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+		Skipped:   s.skipped,
+	}
 }

--- a/v2/pkg/subscraping/sources/threatminer/threatminer.go
+++ b/v2/pkg/subscraping/sources/threatminer/threatminer.go
@@ -4,6 +4,7 @@ package threatminer
 import (
 	"context"
 	"fmt"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -17,11 +18,14 @@ type response struct {
 }
 
 // Source is the passive scraping agent
-type Source struct{}
+type Source struct {
+	timeTaken time.Duration
+}
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -45,6 +49,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		for _, subdomain := range data.Results {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -69,4 +74,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/threatminer/threatminer.go
+++ b/v2/pkg/subscraping/sources/threatminer/threatminer.go
@@ -20,19 +20,26 @@ type response struct {
 // Source is the passive scraping agent
 type Source struct {
 	timeTaken time.Duration
+	errors    int
+	results   int
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://api.threatminer.org/v2/domain.php?q=%s&rt=5", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -43,13 +50,14 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		err = jsoniter.NewDecoder(resp.Body).Decode(&data)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			return
 		}
 
 		for _, subdomain := range data.Results {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+			s.results++
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -76,6 +84,10 @@ func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
 }

--- a/v2/pkg/subscraping/sources/virustotal/virustotal.go
+++ b/v2/pkg/subscraping/sources/virustotal/virustotal.go
@@ -4,6 +4,7 @@ package virustotal
 import (
 	"context"
 	"fmt"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -16,12 +17,14 @@ type response struct {
 
 // Source is the passive scraping agent
 type Source struct {
-	apiKeys []string
+	apiKeys   []string
+	timeTaken time.Duration
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -51,6 +54,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		for _, subdomain := range data.Subdomains {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -75,4 +79,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/waybackarchive/waybackarchive.go
+++ b/v2/pkg/subscraping/sources/waybackarchive/waybackarchive.go
@@ -15,19 +15,26 @@ import (
 // Source is the passive scraping agent
 type Source struct {
 	timeTaken time.Duration
+	errors    int
+	results   int
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("http://web.archive.org/cdx/search/cdx?url=*.%s/*&output=txt&fl=original&collapse=urlkey", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -49,9 +56,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				subdomain = strings.TrimPrefix(subdomain, "2f")
 
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+				s.results++
 			}
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -78,6 +85,10 @@ func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
 }

--- a/v2/pkg/subscraping/sources/waybackarchive/waybackarchive.go
+++ b/v2/pkg/subscraping/sources/waybackarchive/waybackarchive.go
@@ -7,16 +7,20 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 )
 
 // Source is the passive scraping agent
-type Source struct{}
+type Source struct {
+	timeTaken time.Duration
+}
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -47,6 +51,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 			}
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -71,4 +76,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(_ []string) {
 	// no key needed
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/sources/whoisxmlapi/whoisxmlapi.go
+++ b/v2/pkg/subscraping/sources/whoisxmlapi/whoisxmlapi.go
@@ -31,24 +31,33 @@ type Record struct {
 type Source struct {
 	apiKeys   []string
 	timeTaken time.Duration
+	errors    int
+	results   int
+	skipped   bool
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		randomApiKey := subscraping.PickRandom(s.apiKeys, s.Name())
 		if randomApiKey == "" {
+			s.skipped = true
 			return
 		}
 
 		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://subdomains.whoisxmlapi.com/api/v1?apiKey=%s&domainName=%s", randomApiKey, domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			session.DiscardHTTPResponse(resp)
 			return
 		}
@@ -57,6 +66,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		err = jsoniter.NewDecoder(resp.Body).Decode(&data)
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
 			resp.Body.Close()
 			return
 		}
@@ -65,8 +75,8 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 		for _, record := range data.Result.Records {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: record.Domain}
+			s.results++
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -93,6 +103,11 @@ func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+		Skipped:   s.skipped,
+	}
 }

--- a/v2/pkg/subscraping/sources/zoomeyeapi/zoomeyeapi.go
+++ b/v2/pkg/subscraping/sources/zoomeyeapi/zoomeyeapi.go
@@ -24,18 +24,26 @@ type zoomeyeResults struct {
 type Source struct {
 	apiKeys   []string
 	timeTaken time.Duration
+	errors    int
+	results   int
+	skipped   bool
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
-	startTime := time.Now()
+	s.errors = 0
+	s.results = 0
 
 	go func() {
-		defer close(results)
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
 
 		randomApiKey := subscraping.PickRandom(s.apiKeys, s.Name())
 		if randomApiKey == "" {
+			s.skipped = true
 			return
 		}
 
@@ -52,6 +60,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			if err != nil {
 				if !isForbidden {
 					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+					s.errors++
 					session.DiscardHTTPResponse(resp)
 				}
 				return
@@ -62,6 +71,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 			if err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+				s.errors++
 				_ = resp.Body.Close()
 				return
 			}
@@ -69,9 +79,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			pages = int(res.Total/1000) + 1
 			for _, r := range res.List {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: r.Name}
+				s.results++
 			}
 		}
-		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -98,6 +108,11 @@ func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
 }
 
-func (s *Source) TimeTaken() time.Duration {
-	return s.timeTaken
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+		Skipped:   s.skipped,
+	}
 }

--- a/v2/pkg/subscraping/sources/zoomeyeapi/zoomeyeapi.go
+++ b/v2/pkg/subscraping/sources/zoomeyeapi/zoomeyeapi.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 )
@@ -21,12 +22,14 @@ type zoomeyeResults struct {
 
 // Source is the passive scraping agent
 type Source struct {
-	apiKeys []string
+	apiKeys   []string
+	timeTaken time.Duration
 }
 
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
+	startTime := time.Now()
 
 	go func() {
 		defer close(results)
@@ -68,6 +71,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: r.Name}
 			}
 		}
+		s.timeTaken = time.Since(startTime)
 	}()
 
 	return results
@@ -92,4 +96,8 @@ func (s *Source) NeedsKey() bool {
 
 func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
+}
+
+func (s *Source) TimeTaken() time.Duration {
+	return s.timeTaken
 }

--- a/v2/pkg/subscraping/types.go
+++ b/v2/pkg/subscraping/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/projectdiscovery/ratelimit"
 )
@@ -51,10 +52,11 @@ type Session struct {
 
 // Result is a result structure returned by a source
 type Result struct {
-	Type   ResultType
-	Source string
-	Value  string
-	Error  error
+	Type      ResultType
+	Source    string
+	Value     string
+	TimeTaken time.Duration
+	Error     error
 }
 
 // ResultType is the type of result returned by the source

--- a/v2/pkg/subscraping/types.go
+++ b/v2/pkg/subscraping/types.go
@@ -15,6 +15,14 @@ type BasicAuth struct {
 	Password string
 }
 
+// Statistics contains statistics about the scraping process
+type Statistics struct {
+	TimeTaken time.Duration
+	Errors    int
+	Results   int
+	Skipped   bool
+}
+
 // Source is an interface inherited by each passive source
 type Source interface {
 	// Run takes a domain as argument and a session object
@@ -39,8 +47,8 @@ type Source interface {
 
 	AddApiKeys([]string)
 
-	// TimeTaken returns the time.Duration for the source to run
-	TimeTaken() time.Duration
+	// Statistics returns the scrapping statistics for the source
+	Statistics() Statistics
 }
 
 // Session is the option passed to the source, an option is created

--- a/v2/pkg/subscraping/types.go
+++ b/v2/pkg/subscraping/types.go
@@ -21,6 +21,7 @@ type Source interface {
 	// which contains the extractor for subdomains, http client
 	// and other stuff.
 	Run(context.Context, string, *Session) <-chan Result
+
 	// Name returns the name of the source. It is preferred to use lower case names.
 	Name() string
 
@@ -37,6 +38,9 @@ type Source interface {
 	NeedsKey() bool
 
 	AddApiKeys([]string)
+
+	// TimeTaken returns the time.Duration for the source to run
+	TimeTaken() time.Duration
 }
 
 // Session is the option passed to the source, an option is created
@@ -52,11 +56,10 @@ type Session struct {
 
 // Result is a result structure returned by a source
 type Result struct {
-	Type      ResultType
-	Source    string
-	Value     string
-	TimeTaken time.Duration
-	Error     error
+	Type   ResultType
+	Source string
+	Value  string
+	Error  error
 }
 
 // ResultType is the type of result returned by the source


### PR DESCRIPTION
- Add a duration field to the `subscraping.Result` struct
- Populate the `TimeTaken` field before passing to the result channel

I've tried to be as light touch as possible - if this option isn't desirable I thought about adding a `map[string]map[string]time.Duration` to the `Agent` and storing the sources time taken for a given domain against the agent and surface that way.

If that would be more desirable, happy to rework the PR for that

Resolves https://github.com/projectdiscovery/subfinder/issues/726

```
[INF] Found 7 subdomains for 'owenrumney.co.uk' in 30 seconds 357 milliseconds
[INF] Printing source statistics for 'owenrumney.co.uk'

 Source               Duration      Results     Errors
────────────────────────────────────────────────────────
 alienvault           776ms              47          0
 anubis               123ms               0          1
 commoncrawl          30.354s             0          0
 crtsh                186ms              86          0
 digitorus            255ms              93          0
 dnsdb                0s                  0          0
 dnsdumpster          2.975s              5          0
 hackertarget         727ms               0          0
 rapiddns             24.069s             1          0
 riddler              123ms               0          0
 sitedossier          8.469s              0          1
 virustotal           0s                  0          0
 waybackarchive       577ms             343          0

 The following sources were skipped...

 bevigil
 binaryedge
 bufferover
 c99
 censys
 certspotter
 chaos
 chinaz
 dnsrepo
 fofa
 fullhunt
 github
 hunter
 intelx
 passivetotal
 quake
 robtex
 securitytrails
 shodan
 threatbook
 whoisxmlapi
 zoomeye
 zoomeyeapi

```