### PR TITLE
Build from source in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,16 @@
 
 FROM golang:1.20.1-alpine AS build-env
 RUN apk add build-base
-RUN go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
+WORKDIR /app
+COPY . /app
+WORKDIR /app/v2
+RUN go mod download
+RUN go build ./cmd/subfinder
 
 # Release
 FROM alpine:3.17.2
 RUN apk -U upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates
-COPY --from=build-env /go/bin/subfinder /usr/local/bin/subfinder
+COPY --from=build-env /app/v2/subfinder /usr/local/bin/subfinder
 
 ENTRYPOINT ["subfinder"]


### PR DESCRIPTION
This change builds subfinder from source instead of grabbing it from GitHub, fixing the race condition during the release process where the latest version doesn't make it into the Docker build.

Fixes #770 