### PR TITLE
support to load provider keys from env

### DIFF
--- a/v2/pkg/runner/config.go
+++ b/v2/pkg/runner/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/subfinder/v2/pkg/passive"
+	fileutil "github.com/projectdiscovery/utils/file"
 )
 
 // GetConfigDirectory gets the subfinder config directory for a user
@@ -42,14 +43,13 @@ func CreateProviderConfigYAML(configFilePath string, sourcesRequiringApiKeysMap 
 
 // UnmarshalFrom writes the marshaled yaml config to disk
 func UnmarshalFrom(file string) error {
-	f, err := os.Open(file)
+	reader, err := fileutil.SubstituteConfigFromEnvVars(file)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
 	sourceApiKeysMap := map[string][]string{}
-	err = yaml.NewDecoder(f).Decode(sourceApiKeysMap)
+	err = yaml.NewDecoder(reader).Decode(sourceApiKeysMap)
 	for _, source := range passive.AllSources {
 		sourceName := strings.ToLower(source.Name())
 		apiKeys := sourceApiKeysMap[sourceName]


### PR DESCRIPTION
## Proposed changes

- it is now possible to load api keys of providers/sources from env by specifying them in provider-config.yaml file

example:
```yaml
binaryedge:
  - $BINARY_EDGE_API_KEY
```

```console
$ ./subfinder -pc ~/test-templates/testfile.yaml -d hackerone.com -s binaryedge -v

               __    _____           __         
   _______  __/ /_  / __(_)___  ____/ /__  _____
  / ___/ / / / __ \/ /_/ / __ \/ __  / _ \/ ___/
 (__  ) /_/ / /_/ / __/ / / / / /_/ /  __/ /    
/____/\__,_/_.___/_/ /_/_/ /_/\__,_/\___/_/

		projectdiscovery.io

[INF] Current subfinder version v2.5.9 (latest)
[INF] Loading provider config from /Users/tarun/test-templates/testfile.yaml
[DBG] API key(s) found for binaryedge.
[DBG] Selected source(s) for this search: binaryedge
[INF] Enumerating subdomains for hackerone.com
[binaryedge] mta-sts.managed.hackerone.com
[binaryedge] mta-sts.hackerone.com
[binaryedge] mta-sts.forwarding.hackerone.com
[binaryedge] a.ns.hackerone.com
[binaryedge] b.ns.hackerone.com
[binaryedge] docs.hackerone.com
[binaryedge] go.hackerone.com
[binaryedge] info.hackerone.com
[binaryedge] links.hackerone.com
[binaryedge] support.hackerone.com
[binaryedge] api.hackerone.com
[binaryedge] www.hackerone.com
mta-sts.hackerone.com
mta-sts.forwarding.hackerone.com
a.ns.hackerone.com
docs.hackerone.com
go.hackerone.com
support.hackerone.com
api.hackerone.com
www.hackerone.com
mta-sts.managed.hackerone.com
b.ns.hackerone.com
info.hackerone.com
links.hackerone.com
[INF] Found 12 subdomains for hackerone.com in 997 milliseconds 794 microseconds
```