### PR TITLE
Add warning for passivetotal

### DIFF
--- a/v2/pkg/passive/sources.go
+++ b/v2/pkg/passive/sources.go
@@ -33,7 +33,6 @@ import (
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/intelx"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/leakix"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/netlas"
-	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/passivetotal"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/quake"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/rapiddns"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/riddler"
@@ -74,7 +73,7 @@ var AllSources = [...]subscraping.Source{
 	&intelx.Source{},
 	&netlas.Source{},
 	&leakix.Source{},
-	&passivetotal.Source{},
+	// &passivetotal.Source{}, //Redirects to MS Defender TI, no API.
 	&quake.Source{},
 	&rapiddns.Source{},
 	&riddler.Source{},

--- a/v2/pkg/passive/sources.go
+++ b/v2/pkg/passive/sources.go
@@ -33,6 +33,7 @@ import (
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/intelx"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/leakix"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/netlas"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/passivetotal"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/quake"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/rapiddns"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/riddler"
@@ -73,7 +74,7 @@ var AllSources = [...]subscraping.Source{
 	&intelx.Source{},
 	&netlas.Source{},
 	&leakix.Source{},
-	// &passivetotal.Source{}, //Redirects to MS Defender TI, no API.
+	&passivetotal.Source{},
 	&quake.Source{},
 	&rapiddns.Source{},
 	&riddler.Source{},

--- a/v2/pkg/passive/sources.go
+++ b/v2/pkg/passive/sources.go
@@ -93,11 +93,19 @@ var AllSources = [...]subscraping.Source{
 	// &reconcloud.Source{}, // failing due to cloudflare bot protection
 }
 
+var sourceWarnings = map[string]string{
+	"passivetotal": "New API credentials for PassiveTotal can't be generated, but existing user account credentials are still functional. Please ensure your integrations are using valid credentials.",
+}
+
 var NameSourceMap = make(map[string]subscraping.Source, len(AllSources))
 
 func init() {
 	for _, currentSource := range AllSources {
 		NameSourceMap[strings.ToLower(currentSource.Name())] = currentSource
+
+		if warning, ok := sourceWarnings[strings.ToLower(currentSource.Name())]; ok {
+			gologger.Warning().Msg(warning)
+		}
 	}
 }
 
@@ -147,6 +155,12 @@ func New(sourceNames, excludedSourceNames []string, useAllSources, useSourcesSup
 	}
 
 	gologger.Debug().Msgf(fmt.Sprintf("Selected source(s) for this search: %s", strings.Join(maps.Keys(sources), ", ")))
+
+	for _, currentSource := range sources {
+		if warning, ok := sourceWarnings[strings.ToLower(currentSource.Name())]; ok {
+			gologger.Warning().Msg(warning)
+		}
+	}
 
 	// Create the agent, insert the sources and remove the excluded sources
 	agent := &Agent{sources: maps.Values(sources)}


### PR DESCRIPTION
Closes #920.

Note: After reviewing again, we found that the old users can still generate API credentials which they can use for PassiveTotal source, but the same wasn't possible with the new users. I updated the PR by adding a warning to inform users of this.