### PR TITLE
use `-short`mode for excluding long running tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,12 +6,12 @@ on:
       - '**.go'
       - '**.mod'
   workflow_dispatch:
-  inputs:
+    inputs:
       short:
         description: 'Use -short flag for tests'
         required: false
         type: boolean
-        default: 'false'
+        default: false
 
 jobs:  
   build:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,6 +6,12 @@ on:
       - '**.go'
       - '**.mod'
   workflow_dispatch:
+  inputs:
+      short:
+        description: 'Use -short flag for tests'
+        required: false
+        type: boolean
+        default: 'false'
 
 jobs:  
   build:
@@ -59,7 +65,7 @@ jobs:
         with:
           timeout_seconds: 360
           max_attempts: 3
-          command: cd v2; go test ./... -v
+          command: cd v2; go test ./... -v ${{ github.event.inputs.short == 'true' && '-short' || '' }}
 
       - name: Race Condition Tests
         run: go build -race ./...

--- a/v2/pkg/passive/sources_w_auth_test.go
+++ b/v2/pkg/passive/sources_w_auth_test.go
@@ -19,6 +19,10 @@ import (
 )
 
 func TestSourcesWithKeys(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	domain := "hackerone.com"
 	timeout := 60
 

--- a/v2/pkg/passive/sources_wo_auth_test.go
+++ b/v2/pkg/passive/sources_wo_auth_test.go
@@ -19,6 +19,10 @@ import (
 )
 
 func TestSourcesWithoutKeys(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	ignoredSources := []string{
 		"commoncrawl",  // commoncrawl is under resourced and will likely time-out so step over it for this test https://groups.google.com/u/2/g/common-crawl/c/3QmQjFA_3y4/m/vTbhGqIBBQAJ
 		"riddler",      // Fails with 403: There might be too much traffic or a configuration error

--- a/v2/pkg/subscraping/sources/facebook/ctlogs_test.go
+++ b/v2/pkg/subscraping/sources/facebook/ctlogs_test.go
@@ -18,6 +18,10 @@ var (
 )
 
 func TestFacebookSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	updateWithEnv(&fb_API_ID)
 	updateWithEnv(&fb_API_SECRET)
 	if generic.EqualsAny("", fb_API_ID, fb_API_SECRET) {


### PR DESCRIPTION
### Proposed Solution:

1. Consider segregating tests related to problematic APIs into a separate GitHub Action.
2. Implement an environment variable to toggle these tests on/off, ensuring core tests run smoothly.

Closes #946.