### PR TITLE
refactor extractor

### DIFF
--- a/v2/pkg/subscraping/extractor.go
+++ b/v2/pkg/subscraping/extractor.go
@@ -1,0 +1,30 @@
+package subscraping
+
+import (
+	"regexp"
+	"strings"
+)
+
+// RegexSubdomainExtractor is a concrete implementation of the SubdomainExtractor interface, using regex for extraction.
+type RegexSubdomainExtractor struct {
+	extractor *regexp.Regexp
+}
+
+// NewSubdomainExtractor creates a new regular expression to extract
+// subdomains from text based on the given domain.
+func NewSubdomainExtractor(domain string) (*RegexSubdomainExtractor, error) {
+	extractor, err := regexp.Compile(`(?i)[a-zA-Z0-9\*_.-]+\.` + domain)
+	if err != nil {
+		return nil, err
+	}
+	return &RegexSubdomainExtractor{extractor: extractor}, nil
+}
+
+// Extract implements the SubdomainExtractor interface, using the regex to find subdomains in the given text.
+func (re *RegexSubdomainExtractor) Extract(text string) []string {
+	matches := re.extractor.FindAllString(text, -1)
+	for i, match := range matches {
+		matches[i] = strings.ToLower(match)
+	}
+	return matches
+}

--- a/v2/pkg/subscraping/sources/bufferover/bufferover.go
+++ b/v2/pkg/subscraping/sources/bufferover/bufferover.go
@@ -95,7 +95,7 @@ func (s *Source) getData(ctx context.Context, sourceURL string, apiKey string, s
 	}
 
 	for _, subdomain := range subdomains {
-		for _, value := range session.Extractor.FindAllString(subdomain, -1) {
+		for _, value := range session.Extractor.Extract(subdomain) {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: value}
 		}
 		s.results++

--- a/v2/pkg/subscraping/sources/commoncrawl/commoncrawl.go
+++ b/v2/pkg/subscraping/sources/commoncrawl/commoncrawl.go
@@ -142,14 +142,15 @@ func (s *Source) getSubdomains(ctx context.Context, searchURL, domain string, se
 					continue
 				}
 				line, _ = url.QueryUnescape(line)
-				subdomain := session.Extractor.FindString(line)
-				if subdomain != "" {
-					// fix for triple encoded URL
-					subdomain = strings.ToLower(subdomain)
-					subdomain = strings.TrimPrefix(subdomain, "25")
-					subdomain = strings.TrimPrefix(subdomain, "2f")
+				for _, subdomain := range session.Extractor.Extract(line) {
+					if subdomain != "" {
+						// fix for triple encoded URL
+						subdomain = strings.ToLower(subdomain)
+						subdomain = strings.TrimPrefix(subdomain, "25")
+						subdomain = strings.TrimPrefix(subdomain, "2f")
 
-					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+						results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+					}
 				}
 			}
 			resp.Body.Close()

--- a/v2/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/v2/pkg/subscraping/sources/crtsh/crtsh.go
@@ -111,10 +111,11 @@ func (s *Source) getSubdomainsFromSQL(domain string, session *subscraping.Sessio
 
 		count++
 		for _, subdomain := range strings.Split(data, "\n") {
-			value := session.Extractor.FindString(subdomain)
-			if value != "" {
-				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: value}
-				s.results++
+			for _, value := range session.Extractor.Extract(subdomain) {
+				if value != "" {
+					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: value}
+					s.results++
+				}
 			}
 		}
 	}
@@ -143,11 +144,12 @@ func (s *Source) getSubdomainsFromHTTP(ctx context.Context, domain string, sessi
 
 	for _, subdomain := range subdomains {
 		for _, sub := range strings.Split(subdomain.NameValue, "\n") {
-			value := session.Extractor.FindString(sub)
-			if value != "" {
-				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: value}
+			for _, value := range session.Extractor.Extract(sub) {
+				if value != "" {
+					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: value}
+				}
+				s.results++
 			}
-			s.results++
 		}
 	}
 

--- a/v2/pkg/subscraping/sources/digitorus/digitorus.go
+++ b/v2/pkg/subscraping/sources/digitorus/digitorus.go
@@ -49,7 +49,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			if line == "" {
 				continue
 			}
-			subdomains := session.Extractor.FindAllString(line, -1)
+			subdomains := session.Extractor.Extract(line)
 			for _, subdomain := range subdomains {
 				results <- subscraping.Result{
 					Source: s.Name(), Type: subscraping.Subdomain, Value: strings.TrimPrefix(subdomain, "."),

--- a/v2/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/v2/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -103,7 +103,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
-		for _, subdomain := range session.Extractor.FindAllString(data, -1) {
+		for _, subdomain := range session.Extractor.Extract(data) {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 			s.results++
 		}

--- a/v2/pkg/subscraping/sources/hackertarget/hackertarget.go
+++ b/v2/pkg/subscraping/sources/hackertarget/hackertarget.go
@@ -45,7 +45,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			if line == "" {
 				continue
 			}
-			match := session.Extractor.FindAllString(line, -1)
+			match := session.Extractor.Extract(line)
 			for _, subdomain := range match {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 				s.results++

--- a/v2/pkg/subscraping/sources/rapiddns/rapiddns.go
+++ b/v2/pkg/subscraping/sources/rapiddns/rapiddns.go
@@ -47,7 +47,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		resp.Body.Close()
 
 		src := string(body)
-		for _, subdomain := range session.Extractor.FindAllString(src, -1) {
+		for _, subdomain := range session.Extractor.Extract(src) {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 			s.results++
 		}

--- a/v2/pkg/subscraping/sources/riddler/riddler.go
+++ b/v2/pkg/subscraping/sources/riddler/riddler.go
@@ -43,8 +43,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			if line == "" {
 				continue
 			}
-			subdomain := session.Extractor.FindString(line)
-			if subdomain != "" {
+			for _, subdomain := range session.Extractor.Extract(line) {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 				s.results++
 			}

--- a/v2/pkg/subscraping/sources/sitedossier/sitedossier.go
+++ b/v2/pkg/subscraping/sources/sitedossier/sitedossier.go
@@ -51,7 +51,7 @@ func (a *agent) enumerate(ctx context.Context, baseURL string) {
 	resp.Body.Close()
 
 	src := string(body)
-	for _, match := range a.session.Extractor.FindAllString(src, -1) {
+	for _, match := range a.session.Extractor.Extract(src) {
 		a.results <- subscraping.Result{Source: "sitedossier", Type: subscraping.Subdomain, Value: match}
 	}
 

--- a/v2/pkg/subscraping/sources/waybackarchive/waybackarchive.go
+++ b/v2/pkg/subscraping/sources/waybackarchive/waybackarchive.go
@@ -48,8 +48,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				continue
 			}
 			line, _ = url.QueryUnescape(line)
-			subdomain := session.Extractor.FindString(line)
-			if subdomain != "" {
+			for _, subdomain := range session.Extractor.Extract(line) {
 				// fix for triple encoded URL
 				subdomain = strings.ToLower(subdomain)
 				subdomain = strings.TrimPrefix(subdomain, "25")

--- a/v2/pkg/subscraping/types.go
+++ b/v2/pkg/subscraping/types.go
@@ -3,7 +3,6 @@ package subscraping
 import (
 	"context"
 	"net/http"
-	"regexp"
 	"time"
 
 	"github.com/projectdiscovery/ratelimit"
@@ -62,11 +61,16 @@ type Source interface {
 	Statistics() Statistics
 }
 
+// SubdomainExtractor is an interface that defines the contract for subdomain extraction.
+type SubdomainExtractor interface {
+	Extract(text string) []string
+}
+
 // Session is the option passed to the source, an option is created
 // uniquely for each source.
 type Session struct {
-	// Extractor is the regex for subdomains created for each domain
-	Extractor *regexp.Regexp
+	//SubdomainExtractor
+	Extractor SubdomainExtractor
 	// Client is the current http client
 	Client *http.Client
 	// Rate limit instance

--- a/v2/pkg/subscraping/utils.go
+++ b/v2/pkg/subscraping/utils.go
@@ -2,23 +2,12 @@ package subscraping
 
 import (
 	"math/rand"
-	"regexp"
 	"strings"
 
 	"github.com/projectdiscovery/gologger"
 )
 
 const MultipleKeyPartsLength = 2
-
-// NewSubdomainExtractor creates a new regular expression to extract
-// subdomains from text based on the given domain.
-func NewSubdomainExtractor(domain string) (*regexp.Regexp, error) {
-	extractor, err := regexp.Compile(`(?i)[a-zA-Z0-9\*_.-]+\.` + domain)
-	if err != nil {
-		return nil, err
-	}
-	return extractor, nil
-}
 
 func PickRandom[T any](v []T, sourceName string) T {
 	var result T


### PR DESCRIPTION
Closes #798.

before:
```console
$ go run main.go -d nvidia.com

               __    _____           __         
   _______  __/ /_  / __(_)___  ____/ /__  _____
  / ___/ / / / __ \/ /_/ / __ \/ __  / _ \/ ___/
 (__  ) /_/ / /_/ / __/ / / / / /_/ /  __/ /    
/____/\__,_/_.___/_/ /_/_/ /_/\__,_/\___/_/

                projectdiscovery.io

[INF] Current subfinder version v2.6.4-dev (development)
[INF] Loading provider config from /home/vscode/.config/subfinder/provider-config.yaml
[INF] Enumerating subdomains for nvidia.com
...
[INF] Found 1968 subdomains for nvidia.com in 10 seconds 31 milliseconds
```

after:
```console
$ go run main.go -d nvidia.com

               __    _____           __         
   _______  __/ /_  / __(_)___  ____/ /__  _____
  / ___/ / / / __ \/ /_/ / __ \/ __  / _ \/ ___/
 (__  ) /_/ / /_/ / __/ / / / / /_/ /  __/ /    
/____/\__,_/_.___/_/ /_/_/ /_/\__,_/\___/_/

                projectdiscovery.io

[INF] Current subfinder version v2.6.4-dev (development)
[INF] Loading provider config from /home/vscode/.config/subfinder/provider-config.yaml
[INF] Enumerating subdomains for nvidia.com
...
[INF] Found 1973 subdomains for nvidia.com in 12 seconds 851 milliseconds
```