### PR TITLE
normalize input -same as `goflags.NormalizedStringSliceOptions`

### DIFF
--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -114,7 +114,7 @@ func (r *Runner) EnumerateMultipleDomainsWithCtx(ctx context.Context, reader io.
 	scanner := bufio.NewScanner(reader)
 	ip, _ := regexp.Compile(`^([0-9\.]+$)`)
 	for scanner.Scan() {
-		domain, err := sanitize(scanner.Text())
+		domain, err := sanitize(normalizeLowercase(scanner.Text()))
 		isIp := ip.MatchString(domain)
 		if errors.Is(err, ErrEmptyInput) || (r.options.ExcludeIps && isIp) {
 			continue

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -114,7 +114,7 @@ func (r *Runner) EnumerateMultipleDomainsWithCtx(ctx context.Context, reader io.
 	scanner := bufio.NewScanner(reader)
 	ip, _ := regexp.Compile(`^([0-9\.]+$)`)
 	for scanner.Scan() {
-		domain, err := sanitize(normalizeLowercase(scanner.Text()))
+		domain, err := normalizeLowercase(scanner.Text())
 		isIp := ip.MatchString(domain)
 		if errors.Is(err, ErrEmptyInput) || (r.options.ExcludeIps && isIp) {
 			continue

--- a/v2/pkg/runner/util.go
+++ b/v2/pkg/runner/util.go
@@ -31,13 +31,14 @@ func loadFromFile(file string) ([]string, error) {
 }
 
 func sanitize(data string) (string, error) {
-	data = strings.Trim(data, "\n\t\"' ")
+	data = strings.Trim(data, "\n\t\"'` ")
 	if data == "" {
 		return "", ErrEmptyInput
 	}
 	return data, nil
 }
 
-func normalizeLowercase(s string) string {
-	return strings.TrimSpace(strings.Trim(strings.TrimSpace(strings.ToLower(s)), string(quotes)))
+func normalizeLowercase(s string) (string, error) {
+	data, err := sanitize(s)
+	return strings.ToLower(data), err
 }

--- a/v2/pkg/runner/util.go
+++ b/v2/pkg/runner/util.go
@@ -10,7 +10,6 @@ import (
 
 var (
 	ErrEmptyInput = errors.New("empty data")
-	quotes        = []rune{'"', '\'', '`'}
 )
 
 func loadFromFile(file string) ([]string, error) {

--- a/v2/pkg/runner/util.go
+++ b/v2/pkg/runner/util.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/projectdiscovery/utils/file"
+	fileutil "github.com/projectdiscovery/utils/file"
 )
 
 var (
 	ErrEmptyInput = errors.New("empty data")
+	quotes        = []rune{'"', '\'', '`'}
 )
 
 func loadFromFile(file string) ([]string, error) {
@@ -35,4 +36,8 @@ func sanitize(data string) (string, error) {
 		return "", ErrEmptyInput
 	}
 	return data, nil
+}
+
+func normalizeLowercase(s string) string {
+	return strings.TrimSpace(strings.Trim(strings.TrimSpace(strings.ToLower(s)), string(quotes)))
 }


### PR DESCRIPTION
```console
$ cat domain.lst 
Google.com

$ go run . -dL domain.lst 

               __    _____           __         
   _______  __/ /_  / __(_)___  ____/ /__  _____
  / ___/ / / / __ \/ /_/ / __ \/ __  / _ \/ ___/
 (__  ) /_/ / /_/ / __/ / / / / /_/ /  __/ /    
/____/\__,_/_.___/_/ /_/_/ /_/\__,_/\___/_/

                projectdiscovery.io

[INF] Current subfinder version v2.6.4-dev (development)
[INF] Loading provider config from /home/vscode/.config/subfinder/provider-config.yaml
[INF] Enumerating subdomains for google.com

...
googleproxy-66-249-83-183.google.com
mailit0-f43.google.com
sandbox.r2.sn-n4v7snlr.c.pack.google.com
mailqk0-f152.google.com
alt83.www.google.com
alt2871.www.google.com
googleproxy-66-249-88-182.google.com
mail-ads.r4.sn-vgqsrnld.c.pack.google.com
[INF] Found 13386 subdomains for google.com in 20 seconds 394 milliseconds
```

Closes #1071.