### PR TITLE
remove limit clause

### DIFF
--- a/v2/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/v2/pkg/subscraping/sources/crtsh/crtsh.go
@@ -72,7 +72,6 @@ func (s *Source) getSubdomainsFromSQL(domain string, session *subscraping.Sessio
 							FROM certificate_and_identities cai
 							WHERE plainto_tsquery('certwatch', $1) @@ identities(cai.CERTIFICATE)
 								AND cai.NAME_VALUE ILIKE ('%' || $1 || '%')
-							LIMIT 10000
 						) sub
 					GROUP BY sub.CERTIFICATE
 			)


### PR DESCRIPTION
Closes #1118

```
No limit
[INF] Found 14164 subdomains for dell.com in 1 minute 7 seconds

With limit
[INF] Found 2646 subdomains for dell.com in 2 seconds 623 milliseconds
```