### PR TITLE
Upgrade alpine to 3.18.6 for security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 RUN go build ./cmd/subfinder
 
 # Release
-FROM alpine:3.18.2
+FROM alpine:3.18.6
 RUN apk upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates
 COPY --from=build-env /app/v2/subfinder /usr/local/bin/


### PR DESCRIPTION
## Proposed changes
Upgrade Dockerfile.

## Details:
The following vulnerabilities are fixed with alpine upgrade from 3.18.2.to 3.18.6:

https://snyk.io/vuln/SNYK-ALPINE318-BUSYBOX-5890990
https://snyk.io/vuln/SNYK-ALPINE318-BUSYBOX-5890990
https://snyk.io/vuln/SNYK-ALPINE318-BUSYBOX-5890990
https://snyk.io/vuln/SNYK-ALPINE318-OPENSSL-6032386
https://snyk.io/vuln/SNYK-ALPINE318-OPENSSL-6032386