### PR TITLE
add subdomaincenter

### DIFF
--- a/v2/pkg/passive/sources.go
+++ b/v2/pkg/passive/sources.go
@@ -42,6 +42,7 @@ import (
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/securitytrails"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/shodan"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/sitedossier"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/subdomaincenter"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/threatbook"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/virustotal"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/waybackarchive"
@@ -93,6 +94,7 @@ var AllSources = [...]subscraping.Source{
 	// &threatminer.Source{}, // failing  api
 	// &reconcloud.Source{}, // failing due to cloudflare bot protection
 	&builtwith.Source{},
+	&subdomaincenter.Source{},
 }
 
 var sourceWarnings = mapsutil.NewSyncLockMap[string, string](

--- a/v2/pkg/passive/sources_test.go
+++ b/v2/pkg/passive/sources_test.go
@@ -53,6 +53,7 @@ var (
 		// "threatminer",
 		// "reconcloud",
 		"builtwith",
+		"subdomaincenter",
 	}
 
 	expectedDefaultSources = []string{
@@ -88,6 +89,7 @@ var (
 		// "threatminer",
 		// "reconcloud",
 		"builtwith",
+		"subdomaincenter",
 	}
 
 	expectedDefaultRecursiveSources = []string{

--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -257,4 +257,5 @@ var defaultRateLimits = []string{
 	"netlas=1/s",
 	// "gitlab=2/s",
 	"github=83/m",
+	"subdomaincenter=2/m",
 }

--- a/v2/pkg/subscraping/sources/subdomaincenter/subdomaincenter.go
+++ b/v2/pkg/subscraping/sources/subdomaincenter/subdomaincenter.go
@@ -1,0 +1,87 @@
+// Package subdomaincenter logic
+package subdomaincenter
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+)
+
+// Source is the passive scraping agent
+type Source struct {
+	timeTaken time.Duration
+	errors    int
+	results   int
+}
+
+// Run function returns all subdomains found with the service
+func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
+	results := make(chan subscraping.Result)
+	s.errors = 0
+	s.results = 0
+
+	go func() {
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
+
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://api.subdomain.center/?domain=%s", domain))
+		if err != nil {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
+			session.DiscardHTTPResponse(resp)
+			return
+		}
+
+		var subdomains []string
+		err = jsoniter.NewDecoder(resp.Body).Decode(&subdomains)
+		if err != nil {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
+			resp.Body.Close()
+			return
+		}
+		resp.Body.Close()
+
+		for _, subdomain := range subdomains {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+			s.results++
+		}
+	}()
+
+	return results
+}
+
+// Name returns the name of the source
+func (s *Source) Name() string {
+	return "subdomaincenter"
+}
+
+func (s *Source) IsDefault() bool {
+	return true
+}
+
+func (s *Source) HasRecursiveSupport() bool {
+	return false
+}
+
+func (s *Source) NeedsKey() bool {
+	return false
+}
+
+func (s *Source) AddApiKeys(_ []string) {
+	// no key needed
+}
+
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
+}


### PR DESCRIPTION
Closes #1309

```console
$ go run . -d hackerone.com -s subdomaincenter

               __    _____           __         
   _______  __/ /_  / __(_)___  ____/ /__  _____
  / ___/ / / / __ \/ /_/ / __ \/ __  / _ \/ ___/
 (__  ) /_/ / /_/ / __/ / / / / /_/ /  __/ /    
/____/\__,_/_.___/_/ /_/_/ /_/\__,_/\___/_/

                projectdiscovery.io

[INF] Current subfinder version v2.6.6 (latest)
[INF] Loading provider config from /Users/dogancanbakir/Library/Application Support/subfinder/provider-config.yaml
[INF] Enumerating subdomains for hackerone.com
o3.email.hackerone.com
zendesk2.hackerone.com
cover-photos-user-content.hackerone.com
email.hackerone.com
links.hackerone.com
mta-sts.hackerone.com
profile-photos-user-content.hackerone.com
zendesk3.hackerone.com
a.ns.hackerone.com
design.hackerone.com
managed.hackerone.com
docs.hackerone.com
invalid.hackerone.com
ns.hackerone.com
o1.email.hackerone.com
support.hackerone.com
1.ns.hackerone.com
25.hackerone.com
api.hackerone.com
o2.email.hackerone.com
sub.hackerone.com
wwww.hackerone.com
zendesk1.hackerone.com
apis.hackerone.com
forwarding.hackerone.com
gslink.hackerone.com
b.ns.hackerone.com
events.hackerone.com
www.hackerone.com
3d.hackerone.com
info.hackerone.com
resources.hackerone.com
test.hackerone.com
gsemail.hackerone.com
mta-sts.forwarding.hackerone.com
mta-sts.managed.hackerone.com
zendesk4.hackerone.com
-tx1.hackerone.com
go.hackerone.com
sts.hackerone.com
[INF] Found 40 subdomains for hackerone.com in 527 milliseconds 17 microseconds
```