### PR TITLE
fix nil deref in source init

### DIFF
--- a/v2/pkg/passive/sources.go
+++ b/v2/pkg/passive/sources.go
@@ -156,6 +156,10 @@ func New(sourceNames, excludedSourceNames []string, useAllSources, useSourcesSup
 		}
 	}
 
+	if len(sources) == 0 {
+		gologger.Fatal().Msg("No sources selected for this search")
+	}
+
 	gologger.Debug().Msgf("Selected source(s) for this search: %s", strings.Join(maps.Keys(sources), ", "))
 
 	for _, currentSource := range sources {


### PR DESCRIPTION
Closes #1390

before:
```console
$ go run . -es binaryedge,hunter,securitytrails -nW -d amp-endpoint1.com -s hunter -v

               __    _____           __         
   _______  __/ /_  / __(_)___  ____/ /__  _____
  / ___/ / / / __ \/ /_/ / __ \/ __  / _ \/ ___/
 (__  ) /_/ / /_/ / __/ / / / / /_/ /  __/ /    
/____/\__,_/_.___/_/ /_/_/ /_/\__,_/\___/_/

                projectdiscovery.io

[INF] Current subfinder version v2.6.6 (latest)
[INF] Loading provider config from /Users/dogancanbakir/Library/Application Support/subfinder/provider-config.yaml
[DBG] API key(s) found for chaos.
[DBG] API key(s) found for fofa.
[DBG] API key(s) found for github.
[DBG] API key(s) found for netlas.
[DBG] API key(s) found for securitytrails.
[DBG] API key(s) found for shodan.
[DBG] API key(s) found for zoomeyeapi.
[DBG] Selected source(s) for this search: 
[INF] Enumerating subdomains for amp-endpoint1.com
[WRN] Could not get wildcards for domain amp-endpoint1.com: amp-endpoint1.com is not a wildcard domain
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x102d904f8]

goroutine 42 [running]:
github.com/projectdiscovery/ratelimit.(*MultiLimiter).Stop(0x140005e5e28?, {0x0?, 0x14000187180?, 0x103072e01?})
        /Users/dogancanbakir/go/pkg/mod/github.com/projectdiscovery/ratelimit@v0.0.55/keyratelimit.go:106 +0x28
github.com/projectdiscovery/subfinder/v2/pkg/subscraping.(*Session).Close(0x140002f6580)
        /Users/dogancanbakir/Projects/subfinder/v2/pkg/subscraping/agent.go:128 +0x34
github.com/projectdiscovery/subfinder/v2/pkg/passive.(*Agent).EnumerateSubdomainsWithCtx.func1()
        /Users/dogancanbakir/Projects/subfinder/v2/pkg/passive/passive.go:77 +0x448
created by github.com/projectdiscovery/subfinder/v2/pkg/passive.(*Agent).EnumerateSubdomainsWithCtx in goroutine 1
        /Users/dogancanbakir/Projects/subfinder/v2/pkg/passive/passive.go:37 +0x130
exit status 2
```


after:
```console 
$ go run . -es binaryedge,hunter,securitytrails -nW -d amp-endpoint1.com -s hunter -v

               __    _____           __         
   _______  __/ /_  / __(_)___  ____/ /__  _____
  / ___/ / / / __ \/ /_/ / __ \/ __  / _ \/ ___/
 (__  ) /_/ / /_/ / __/ / / / / /_/ /  __/ /    
/____/\__,_/_.___/_/ /_/_/ /_/\__,_/\___/_/

                projectdiscovery.io

[INF] Current subfinder version v2.6.6 (latest)
[INF] Loading provider config from /Users/dogancanbakir/Library/Application Support/subfinder/provider-config.yaml
[DBG] API key(s) found for chaos.
[DBG] API key(s) found for fofa.
[DBG] API key(s) found for github.
[DBG] API key(s) found for netlas.
[DBG] API key(s) found for securitytrails.
[DBG] API key(s) found for shodan.
[DBG] API key(s) found for zoomeyeapi.
[FTL] No sources selected for this search
exit status 1
```