### PR TITLE
Add TLD Exclusion Feature (--exclude-tld) to Filter Out Unwanted TLDs

### DIFF
--- a/v2/pkg/runner/options.go
+++ b/v2/pkg/runner/options.go
@@ -67,6 +67,7 @@ type Options struct {
 	filterRegexes      []*regexp.Regexp
 	ResultCallback     OnResultCallback // OnResult callback
 	DisableUpdateCheck bool             // DisableUpdateCheck disable update checking
+	ExcludeTLDs        goflags.StringSlice
 }
 
 // OnResultCallback (hostResult)
@@ -97,6 +98,7 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("filter", "Filter",
 		flagSet.StringSliceVarP(&options.Match, "match", "m", nil, "subdomain or list of subdomain to match (file or comma separated)", goflags.FileNormalizedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.Filter, "filter", "f", nil, " subdomain or list of subdomain to filter (file or comma separated)", goflags.FileNormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.ExcludeTLDs, "exclude-tld", "et", nil, "exclude specified TLD(s) (e.g. .ru, .cn). Can be used multiple times or with file input", goflags.FileNormalizedStringSliceOptions,),
 	)
 
 	flagSet.CreateGroup("rate-limit", "Rate-limit",

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -126,9 +126,9 @@ func (r *Runner) EnumerateMultipleDomainsWithCtx(ctx context.Context, reader io.
 		}
 
 		if r.shouldExcludeDomain(domain) {
-            gologger.Debug().Msgf("Skipping domain %s because TLD is excluded", domain)
-            continue
-        }
+            		gologger.Debug().Msgf("Skipping domain %s because TLD is excluded", domain)
+            		continue
+       		}
 
 		var file *os.File
 		// If the user has specified an output file, use that output file instead

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -175,10 +175,10 @@ func (r *Runner) EnumerateMultipleDomainsWithCtx(ctx context.Context, reader io.
 
 // shouldExcludeDomain checks if the domain ends with any TLD in ExcludeTLDs
 func (r *Runner) shouldExcludeDomain(domain string) bool {
-    for _, tld := range r.options.ExcludeTLDs {
-        if strings.HasSuffix(domain, tld) {
-            return true
-        }
-    }
-    return false
+    	for _, tld := range r.options.ExcludeTLDs {
+        	if strings.HasSuffix(domain, tld) {
+            		return true
+        	}
+    	}
+    	return false
 }

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -125,6 +125,11 @@ func (r *Runner) EnumerateMultipleDomainsWithCtx(ctx context.Context, reader io.
 			continue
 		}
 
+		if r.shouldExcludeDomain(domain) {
+            gologger.Debug().Msgf("Skipping domain %s because TLD is excluded", domain)
+            continue
+        }
+
 		var file *os.File
 		// If the user has specified an output file, use that output file instead
 		// of creating a new output file for each domain. Else create a new file
@@ -166,4 +171,14 @@ func (r *Runner) EnumerateMultipleDomainsWithCtx(ctx context.Context, reader io.
 		}
 	}
 	return nil
+}
+
+// shouldExcludeDomain checks if the domain ends with any TLD in ExcludeTLDs
+func (r *Runner) shouldExcludeDomain(domain string) bool {
+    for _, tld := range r.options.ExcludeTLDs {
+        if strings.HasSuffix(domain, tld) {
+            return true
+        }
+    }
+    return false
 }


### PR DESCRIPTION
**Description:**
This PR introduces a new CLI flag, `--exclude-tld`, which allows users to exclude specific TLDs (e.g., `.ru`, `.cn`) from the final results. 

**Changes:**
- Added `ExcludeTLDs` field in `Options` to store excluded TLDs
- Introduced a new flag, `--exclude-tld (-et)`, which can be specified multiple times
- Implemented filtering logic in `EnumerateMultipleDomainsWithCtx()` to skip subdomains matching the excluded TLD(s)

**Testing:**
- Added a sample domains.txt containing `.cn`, `.ru`, etc.
- Verified that domains ending with these TLDs are not included in the final output

**Example code**
```bash
subfinder -dL domains.txt --exclude-tld .ru --exclude-tld .cn
```

- Related issue: #1530 