### PR TITLE
update dnsrepo api endpoint

### DIFF
--- a/v2/pkg/subscraping/sources/dnsrepo/dnsrepo.go
+++ b/v2/pkg/subscraping/sources/dnsrepo/dnsrepo.go
@@ -21,7 +21,7 @@ type Source struct {
 }
 
 type DnsRepoResponse []struct {
-	Domain string
+	Domain string `json:"domain"`
 }
 
 func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
@@ -50,7 +50,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		token := randomApiInfo[0]
 		apiKey := randomApiInfo[1]
 
-		resp, err := session.Get(ctx, fmt.Sprintf("https://dnsarchive.net/api/?apikey=%s&search=%s", apiKey, domain), "", map[string]string{" X-API-Access": token})
+		resp, err := session.Get(ctx, fmt.Sprintf("https://dnsarchive.net/api/?apikey=%s&search=%s", apiKey, domain), "", map[string]string{"X-API-Access": token})
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			s.errors++

--- a/v2/pkg/subscraping/sources/dnsrepo/dnsrepo.go
+++ b/v2/pkg/subscraping/sources/dnsrepo/dnsrepo.go
@@ -40,7 +40,17 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			s.skipped = true
 			return
 		}
-		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://dnsrepo.noc.org/api/?apikey=%s&search=%s", randomApiKey, domain))
+
+		randomApiInfo := strings.Split(randomApiKey, ":")
+		if len(randomApiInfo) != 2 {
+			s.skipped = true
+			return
+		}
+
+		token := randomApiInfo[0]
+		apiKey := randomApiInfo[1]
+
+		resp, err := session.Get(ctx, fmt.Sprintf("https://dnsarchive.net/api/?apikey=%s&search=%s", apiKey, domain), "", map[string]string{" X-API-Access": token})
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			s.errors++


### PR DESCRIPTION
Closes #1538


```console
$ go run . -d hackerone.com -s dnsrepo

               __    _____           __         
   _______  __/ /_  / __(_)___  ____/ /__  _____
  / ___/ / / / __ \/ /_/ / __ \/ __  / _ \/ ___/
 (__  ) /_/ / /_/ / __/ / / / / /_/ /  __/ /    
/____/\__,_/_.___/_/ /_/_/ /_/\__,_/\___/_/

                projectdiscovery.io

[INF] Current subfinder version v2.6.8 (latest)
[INF] Loading provider config from /Users/dogancanbakir/Library/Application Support/subfinder/provider-config.yaml
[INF] Enumerating subdomains for hackerone.com
mta-sts.managed.hackerone.com
resources.hackerone.com
...
```