### PR TITLE
fix(v2/pkg/subscraping): Fix Hunter data source paging issue

### DIFF
--- a/v2/pkg/subscraping/sources/hunter/hunter.go
+++ b/v2/pkg/subscraping/sources/hunter/hunter.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	jsoniter "github.com/json-iterator/go"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 )
 
@@ -57,10 +57,48 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		}
 
 		var pages = 1
-		for currentPage := 1; currentPage <= pages; currentPage++ {
-			// hunter api doc https://hunter.qianxin.com/home/helpCenter?r=5-1-2
+
+		// hunter api doc https://hunter.qianxin.com/home/helpCenter?r=5-1-2
+		qbase64 := base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("domain=\"%s\"", domain)))
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://hunter.qianxin.com/openApi/search?api-key=%s&search=%s&page=1&page_size=100&is_web=3", randomApiKey, qbase64))
+		if err != nil && resp == nil {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
+			session.DiscardHTTPResponse(resp)
+			return
+		}
+
+		var response hunterResp
+		err = jsoniter.NewDecoder(resp.Body).Decode(&response)
+		if err != nil {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
+			resp.Body.Close()
+			return
+		}
+		resp.Body.Close()
+
+		if response.Code == 401 || response.Code == 400 {
+			results <- subscraping.Result{
+				Source: s.Name(), Type: subscraping.Error, Error: fmt.Errorf("%s", response.Message),
+			}
+			s.errors++
+			return
+		}
+
+		if response.Data.Total > 0 {
+			for _, hunterInfo := range response.Data.InfoArr {
+				subdomain := hunterInfo.Domain
+				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+				s.results++
+			}
+		}
+		// get all pages
+		pages = int(response.Data.Total/100) + 1
+		//Perform page turning operation
+		for currentPage := 2; currentPage <= pages; currentPage++ {
 			qbase64 := base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("domain=\"%s\"", domain)))
-			resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://hunter.qianxin.com/openApi/search?api-key=%s&search=%s&page=1&page_size=100&is_web=3", randomApiKey, qbase64))
+			resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://hunter.qianxin.com/openApi/search?api-key=%s&search=%s&page=%d&page_size=100&is_web=3", randomApiKey, qbase64, currentPage))
 			if err != nil && resp == nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 				s.errors++
@@ -93,7 +131,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 					s.results++
 				}
 			}
-			pages = int(response.Data.Total/1000) + 1
+			time.Sleep(time.Millisecond * 500)
 		}
 	}()
 

--- a/v2/pkg/subscraping/sources/quake/quake.go
+++ b/v2/pkg/subscraping/sources/quake/quake.go
@@ -56,9 +56,10 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			s.skipped = true
 			return
 		}
-
+		//翻页设计
+		var pages = 1
 		// quake api doc https://quake.360.cn/quake/#/help
-		var requestBody = []byte(fmt.Sprintf(`{"query":"domain: %s", "include":["service.http.host"], "latest": true, "start":0, "size":500}`, domain))
+		var requestBody = []byte(fmt.Sprintf(`{"query":"domain: %s", "include":["service.http.host"], "latest": true, "start":0, "size":500 ,"latest":true}`, domain))
 		resp, err := session.Post(ctx, "https://quake.360.net/api/v3/search/quake_service", "", map[string]string{
 			"Content-Type": "application/json", "X-QuakeToken": randomApiKey,
 		}, bytes.NewReader(requestBody))
@@ -95,6 +96,52 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				}
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 				s.results++
+			}
+		}
+
+		// get all pages
+		pages = int(response.Meta.Pagination.Total/500) + 1
+		for currentPage := 2; currentPage <= pages; currentPage++ {
+			//Preform page turning operaation
+			var start = (currentPage - 1) * 500
+			var requestBody = []byte(fmt.Sprintf(`{"query":"domain: %s", "include":["service.http.host"], "latest": true, "start":%d, "size":500 ,"latest":true}`, domain, start))
+			resp, err := session.Post(ctx, "https://quake.360.net/api/v3/search/quake_service", "", map[string]string{
+				"Content-Type": "application/json", "X-QuakeToken": randomApiKey,
+			}, bytes.NewReader(requestBody))
+			if err != nil {
+				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+				s.errors++
+				session.DiscardHTTPResponse(resp)
+				return
+			}
+
+			var response quakeResults
+			err = jsoniter.NewDecoder(resp.Body).Decode(&response)
+			if err != nil {
+				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+				s.errors++
+				resp.Body.Close()
+				return
+			}
+			resp.Body.Close()
+
+			if response.Code != 0 {
+				results <- subscraping.Result{
+					Source: s.Name(), Type: subscraping.Error, Error: fmt.Errorf("%s", response.Message),
+				}
+				s.errors++
+				return
+			}
+
+			if response.Meta.Pagination.Total > 0 {
+				for _, quakeDomain := range response.Data {
+					subdomain := quakeDomain.Service.HTTP.Host
+					if strings.ContainsAny(subdomain, "暂无权限") {
+						subdomain = ""
+					}
+					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+					s.results++
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
Optimized the pagination logic of Hunter scanning source, which can correctly obtain multi page results
-Added requests and processing for pages 2 and beyond

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting for API queries, providing immediate feedback on issues such as invalid credentials or bad requests.
  - Enhanced processing of paginated responses by ensuring the first batch is verified before retrieving additional results.
  - Introduced a brief delay between requests to stabilize data retrieval and reduce potential rate-limit issues.
  
- **New Features**
  - Added pagination handling for API responses, allowing retrieval of multiple pages of results from the Hunter and Quake services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->