### PR TITLE
Update GoReleaser configurations

### DIFF
--- a/v2/.goreleaser.yml
+++ b/v2/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod tidy
@@ -25,7 +27,8 @@ builds:
   main: cmd/subfinder/main.go
 
 archives:
-- format: zip
+- formats:
+    - zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
 
 checksum:


### PR DESCRIPTION
## PR Summary
This small PR updates the GoReleaser configuration to resolve the following warnings which you can find in the [CI logs](https://github.com/projectdiscovery/subfinder/actions/runs/15570778599/job/43845881850#step:4:25): 
```
DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```