### PR TITLE
feat: introduce the passive shrewdeye source

### DIFF
--- a/v2/pkg/passive/sources.go
+++ b/v2/pkg/passive/sources.go
@@ -42,6 +42,7 @@ import (
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/rsecloud"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/securitytrails"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/shodan"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/shrewdeye"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/sitedossier"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/threatbook"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/threatcrowd"
@@ -93,8 +94,7 @@ var AllSources = [...]subscraping.Source{
 	&whoisxmlapi.Source{},
 	&zoomeyeapi.Source{},
 	&facebook.Source{},
-	// &threatminer.Source{}, // failing  api
-	// &reconcloud.Source{}, // failing due to cloudflare bot protection
+	&shrewdeye.Source{},
 	&builtwith.Source{},
 	&hudsonrock.Source{},
 	&digitalyama.Source{},

--- a/v2/pkg/subscraping/sources/shrewdeye/shrewdeye.go
+++ b/v2/pkg/subscraping/sources/shrewdeye/shrewdeye.go
@@ -1,0 +1,91 @@
+// Package shrewdeye logic
+package shrewdeye
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+)
+
+// Source is the passive scraping agent
+type Source struct {
+	timeTaken time.Duration
+	errors    int
+	results   int
+}
+
+// Run function returns all subdomains found with the service
+func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
+	results := make(chan subscraping.Result)
+	s.errors = 0
+	s.results = 0
+
+	go func() {
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
+
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://shrewdeye.app/domains/%s.txt", domain))
+		if err != nil {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
+			session.DiscardHTTPResponse(resp)
+			return
+		}
+
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+				s.errors++
+			}
+		}()
+
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+			match := session.Extractor.Extract(line)
+			for _, subdomain := range match {
+				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+				s.results++
+			}
+		}
+	}()
+
+	return results
+}
+
+// Name returns the name of the source
+func (s *Source) Name() string {
+	return "shrewdeye"
+}
+
+func (s *Source) IsDefault() bool {
+	return true
+}
+
+func (s *Source) HasRecursiveSupport() bool {
+	return false
+}
+
+func (s *Source) NeedsKey() bool {
+	return false
+}
+
+func (s *Source) AddApiKeys(_ []string) {
+	// no key needed
+}
+
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
+}


### PR DESCRIPTION
This pull request introduces a new passive subdomain enumeration source, ShrewdEye.
https://github.com/projectdiscovery/subfinder/issues/1599


ShrewdEye (https://shrewdeye.app) is a free service that provides subdomain information for a given domain. This PR integrates its public API (https://shrewdeye.app/domains/{DOMAIN_NAME}.txt) as a new data source for subfinder.

Created a new source file at v2/pkg/subscraping/sources/shrewdeye/shrewdeye.go.
Registered shrewdeye as a new default passive source in v2/pkg/passive/sources.go.
The source is unauthenticated and does not require an API key.
![img](https://github.com/user-attachments/assets/0c6c9d06-a410-4c17-9ae2-9ad4664c6883)

