### PR TITLE
fix: enforce global timeout using context.WithTimeout

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/projectdiscovery/gologger"
 	contextutil "github.com/projectdiscovery/utils/context"
@@ -80,6 +81,9 @@ func (r *Runner) RunEnumeration() error {
 
 // RunEnumerationWithCtx runs the subdomain enumeration flow on the targets specified
 func (r *Runner) RunEnumerationWithCtx(ctx context.Context) error {
+	timeout := time.Duration(r.options.Timeout) * time.Second
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	outputs := []io.Writer{r.options.Output}
 
 	if len(r.options.Domain) > 0 {


### PR DESCRIPTION
Fixes #1560

### Problem

The `-timeout` flag was inconsistently enforced across different runs. Although HTTP clients respected the timeout value, the overall enumeration process was not constrained, causing long or indefinite execution when sources delayed or hung.

### Root Cause

The CLI-level `-timeout` value was not applied to the root execution context (`RunEnumerationWithCtx`). As a result, even if individual HTTP requests timed out, the global orchestration layer continued waiting for results.

### Changes

* Wrap `RunEnumerationWithCtx` with `context.WithTimeout` using the configured `r.options.Timeout`
* The updated context is passed throughout the enumeration lifecycle
* Now ensures a strict upper bound on total enumeration time, regardless of individual source behavior

### Result

**Before:**

```bash
subfinder -d erlang.org -timeout 5
[INF] Found 10 subdomains for erlang.org in 30 seconds
```

**After:**

```bash
subfinder -d erlang.org -timeout 5
[INF] Found 8 subdomains for erlang.org in 5 seconds
```

Sources that do not return within the timeout window are safely cancelled, resulting in consistent timing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a timeout to the enumeration process, ensuring operations are automatically canceled if they exceed the specified duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->