### PR TITLE
Fix the `build-test` action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -80,3 +80,4 @@ jobs:
 
       - name: Run Example
         run: go run .
+        working-directory: examples


### PR DESCRIPTION
This fixes the `build-test` action by restoring the `examples` working directory.  This was incorrectly removed in the previous commit.