### PR TITLE
add env var support for config files

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-13]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: projectdiscovery/actions/setup/go@v1

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ OPTIMIZATION:
   -max-time int  minutes to wait for enumeration results (default 10)
 ```
 
+## Environment Variables
+
+Subfinder supports environment variables to specify custom paths for configuration files:
+
+- `SUBFINDER_CONFIG` - Path to config.yaml file (overrides default `$CONFIG/subfinder/config.yaml`)
+- `SUBFINDER_PROVIDER_CONFIG` - Path to provider-config.yaml file (overrides default `$CONFIG/subfinder/provider-config.yaml`)
+
 # Installation
 
 `subfinder` requires **go1.24** to install successfully. Run the following command to install the latest version:

--- a/pkg/passive/sources_wo_auth_test.go
+++ b/pkg/passive/sources_wo_auth_test.go
@@ -33,6 +33,7 @@ func TestSourcesWithoutKeys(t *testing.T) {
 		"digitorus",      // failing with "Failed to retrieve certificate"
 		"dnsdumpster",    // failing with "unexpected status code 403 received"
 		"anubis",         // failing with "too many redirects"
+		"threatcrowd",    // failing with "randomly failing with unmarshal error when hit multiple times"
 	}
 
 	domain := "hackerone.com"

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -15,6 +15,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/subfinder/v2/pkg/passive"
 	"github.com/projectdiscovery/subfinder/v2/pkg/resolve"
+	envutil "github.com/projectdiscovery/utils/env"
 	fileutil "github.com/projectdiscovery/utils/file"
 	folderutil "github.com/projectdiscovery/utils/folder"
 	logutil "github.com/projectdiscovery/utils/log"
@@ -23,8 +24,8 @@ import (
 
 var (
 	configDir                     = folderutil.AppConfigDirOrDefault(".", "subfinder")
-	defaultConfigLocation         = filepath.Join(configDir, "config.yaml")
-	defaultProviderConfigLocation = filepath.Join(configDir, "provider-config.yaml")
+	defaultConfigLocation         = envutil.GetEnvOrDefault("SUBFINDER_CONFIG", filepath.Join(configDir, "config.yaml"))
+	defaultProviderConfigLocation = envutil.GetEnvOrDefault("SUBFINDER_PROVIDER_CONFIG", filepath.Join(configDir, "provider-config.yaml"))
 )
 
 // Options contains the configuration options for tuning
@@ -117,14 +118,6 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.CaptureSources, "collect-sources", "cs", false, "include all sources in the output (-json only)"),
 		flagSet.BoolVarP(&options.HostIP, "ip", "oI", false, "include host IP in output (-active only)"),
 	)
-
-	if envConfig := os.Getenv("SUBFINDER_CONFIG"); envConfig != "" {
-		defaultConfigLocation = envConfig
-	}
-
-	if envProviderConfig := os.Getenv("SUBFINDER_PROVIDER_CONFIG"); envProviderConfig != "" {
-		defaultProviderConfigLocation = envProviderConfig
-	}
 
 	flagSet.CreateGroup("configuration", "Configuration",
 		flagSet.StringVar(&options.Config, "config", defaultConfigLocation, "flag config file"),

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -118,6 +118,14 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.HostIP, "ip", "oI", false, "include host IP in output (-active only)"),
 	)
 
+	if envConfig := os.Getenv("SUBFINDER_CONFIG"); envConfig != "" {
+		defaultConfigLocation = envConfig
+	}
+
+	if envProviderConfig := os.Getenv("SUBFINDER_PROVIDER_CONFIG"); envProviderConfig != "" {
+		defaultProviderConfigLocation = envProviderConfig
+	}
+
 	flagSet.CreateGroup("configuration", "Configuration",
 		flagSet.StringVar(&options.Config, "config", defaultConfigLocation, "flag config file"),
 		flagSet.StringVarP(&options.ProviderConfig, "provider-config", "pc", defaultProviderConfigLocation, "provider config file"),


### PR DESCRIPTION
closes https://github.com/projectdiscovery/subfinder/issues/1648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for overriding default configuration file locations via environment variables SUBFINDER_CONFIG and SUBFINDER_PROVIDER_CONFIG.

* **Documentation**
  * Added an Environment Variables section to the README explaining these variables.
  * Clarified installation instructions with a go install command example.

* **Tests**
  * Updated test suite to ignore an additional external data source during passive tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->