### PR TITLE
Return enumerated subdomain results in realtime

### DIFF
--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -129,7 +129,7 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 				if _, ok := foundResults[result.Host]; !ok {
 					foundResults[result.Host] = result
 					if r.options.ResultCallback != nil {
-						r.options.ResultCallback(&resolve.HostEntry{Host: result.Host, Source: result.Source})
+						r.options.ResultCallback(&resolve.HostEntry{Domain: domain, Host: result.Host, Source: result.Source})
 					}
 				}
 			}

--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -94,6 +94,9 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 					}
 
 					hostEntry := resolve.HostEntry{Domain: domain, Host: subdomain, Source: result.Source}
+					if r.options.ResultCallback != nil {
+						r.options.ResultCallback(&hostEntry)
+					}
 
 					uniqueMap[subdomain] = hostEntry
 					// If the user asked to remove wildcard then send on the resolve
@@ -162,17 +165,6 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 		numberOfSubDomains = len(uniqueMap)
 	}
 
-	if r.options.ResultCallback != nil {
-		if r.options.RemoveWildcard {
-			for host, result := range foundResults {
-				r.options.ResultCallback(&resolve.HostEntry{Domain: host, Host: result.Host, Source: result.Source})
-			}
-		} else {
-			for _, v := range uniqueMap {
-				r.options.ResultCallback(&v)
-			}
-		}
-	}
 	gologger.Info().Msgf("Found %d subdomains for %s in %s\n", numberOfSubDomains, domain, duration)
 
 	if r.options.Statistics {

--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -94,7 +94,7 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 					}
 
 					hostEntry := resolve.HostEntry{Domain: domain, Host: subdomain, Source: result.Source}
-					if r.options.ResultCallback != nil {
+					if r.options.ResultCallback != nil && !r.options.RemoveWildcard {
 						r.options.ResultCallback(&hostEntry)
 					}
 
@@ -128,6 +128,9 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 				// Add the found subdomain to a map.
 				if _, ok := foundResults[result.Host]; !ok {
 					foundResults[result.Host] = result
+					if r.options.ResultCallback != nil {
+						r.options.ResultCallback(&resolve.HostEntry{Host: result.Host, Source: result.Source})
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Refer to #1649.

I've not tested the `RemoveWildcard = true` path yet, but the code looks fine to me. I've removed the original `ResultCallback` calls and placed them where they will be called sooner, which is hopefully acceptable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Results now stream in real time: discovered subdomains are emitted immediately, and entries from wildcard resolution are surfaced as they’re resolved. This reduces latency and improves interactive workflows and integrations.

- **Refactor**
  - Removed the final consolidated emission at the end of a run. Consumers should handle streaming updates during execution rather than relying on a single end-of-run callback. Existing output files and wildcard result queuing behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->