### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/pkg/runner/outputter.go
+++ b/pkg/runner/outputter.go
@@ -227,11 +227,12 @@ func writeSourcePlainHost(_ string, sourceMap map[string]map[string]struct{}, wr
 	for host, sources := range sourceMap {
 		sb.WriteString(host)
 		sb.WriteString(",[")
-		sourcesString := ""
+		var sourcesString strings.Builder
 		for source := range sources {
-			sourcesString += source + ","
+			sourcesString.WriteString(source)
+			sourcesString.WriteRune(',')
 		}
-		sb.WriteString(strings.Trim(sourcesString, ", "))
+		sb.WriteString(strings.TrimSuffix(sourcesString.String(), ","))
 		sb.WriteString("]\n")
 
 		_, err := bufwriter.WriteString(sb.String())


### PR DESCRIPTION
strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal performance and memory efficiency of the output processing system by optimizing how per-host source lists are assembled in memory, while preserving existing output format and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->