### PR TITLE
fix: bump version to 2.10.0

### DIFF
--- a/pkg/runner/banners.go
+++ b/pkg/runner/banners.go
@@ -17,7 +17,7 @@ const banner = `
 const ToolName = `subfinder`
 
 // Version is the current version of subfinder
-const version = `v2.9.1-dev`
+const version = `v2.10.0`
 
 // showBanner is used to show the banner to the user
 func showBanner() {


### PR DESCRIPTION
- https://github.com/Homebrew/homebrew-core/pull/254984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal version identifier to v2.10.0; no user-facing behavior or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->