### PR TITLE
Add optional API key support for sources

### DIFF
--- a/pkg/passive/sources.go
+++ b/pkg/passive/sources.go
@@ -184,9 +184,9 @@ func New(sourceNames, excludedSourceNames []string, useAllSources, useSourcesSup
 		}
 	}
 
-	// TODO: Consider refactoring this to avoid potential duplication issues
 	for _, source := range sources {
-		if source.NeedsKey() {
+		keyReq := source.KeyRequirement()
+		if keyReq == subscraping.RequiredKey || keyReq == subscraping.OptionalKey {
 			if apiKey := os.Getenv(fmt.Sprintf("%s_API_KEY", strings.ToUpper(source.Name()))); apiKey != "" {
 				source.AddApiKeys([]string{apiKey})
 			}

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/subfinder/v2/pkg/passive"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 	fileutil "github.com/projectdiscovery/utils/file"
 )
 
@@ -25,7 +26,8 @@ func createProviderConfigYAML(configFilePath string) error {
 
 	sourcesRequiringApiKeysMap := make(map[string][]string)
 	for _, source := range passive.AllSources {
-		if source.NeedsKey() {
+		keyReq := source.KeyRequirement()
+		if keyReq == subscraping.RequiredKey || keyReq == subscraping.OptionalKey {
 			sourceName := strings.ToLower(source.Name())
 			sourcesRequiringApiKeysMap[sourceName] = []string{}
 		}

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -15,6 +15,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/subfinder/v2/pkg/passive"
 	"github.com/projectdiscovery/subfinder/v2/pkg/resolve"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 	envutil "github.com/projectdiscovery/utils/env"
 	fileutil "github.com/projectdiscovery/utils/file"
 	folderutil "github.com/projectdiscovery/utils/folder"
@@ -223,16 +224,20 @@ func (options *Options) loadProvidersFrom(location string) {
 
 func listSources(options *Options) {
 	gologger.Info().Msgf("Current list of available sources. [%d]\n", len(passive.AllSources))
-	gologger.Info().Msgf("Sources marked with an * need key(s) or token(s) to work.\n")
+	gologger.Info().Msgf("Sources marked with an * require key(s) or token(s) to work.\n")
+	gologger.Info().Msgf("Sources marked with a ~ optionally support key(s) for better results.\n")
 	gologger.Info().Msgf("You can modify %s to configure your keys/tokens.\n\n", options.ProviderConfig)
 
 	for _, source := range passive.AllSources {
-		message := "%s\n"
 		sourceName := source.Name()
-		if source.NeedsKey() {
-			message = "%s *\n"
+		switch source.KeyRequirement() {
+		case subscraping.RequiredKey:
+			gologger.Silent().Msgf("%s *\n", sourceName)
+		case subscraping.OptionalKey:
+			gologger.Silent().Msgf("%s ~\n", sourceName)
+		default:
+			gologger.Silent().Msgf("%s\n", sourceName)
 		}
-		gologger.Silent().Msgf(message, sourceName)
 	}
 }
 

--- a/pkg/subscraping/sources/alienvault/alienvault.go
+++ b/pkg/subscraping/sources/alienvault/alienvault.go
@@ -98,8 +98,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return true
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/anubis/anubis.go
+++ b/pkg/subscraping/sources/anubis/anubis.go
@@ -82,8 +82,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return false
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(_ []string) {

--- a/pkg/subscraping/sources/bevigil/bevigil.go
+++ b/pkg/subscraping/sources/bevigil/bevigil.go
@@ -94,8 +94,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/bufferover/bufferover.go
+++ b/pkg/subscraping/sources/bufferover/bufferover.go
@@ -119,8 +119,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return true
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/builtwith/builtwith.go
+++ b/pkg/subscraping/sources/builtwith/builtwith.go
@@ -100,8 +100,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/c99/c99.go
+++ b/pkg/subscraping/sources/c99/c99.go
@@ -107,8 +107,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/censys/censys.go
+++ b/pkg/subscraping/sources/censys/censys.go
@@ -197,8 +197,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 // AddApiKeys parses and adds API keys.

--- a/pkg/subscraping/sources/certspotter/certspotter.go
+++ b/pkg/subscraping/sources/certspotter/certspotter.go
@@ -140,8 +140,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return true
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/chaos/chaos.go
+++ b/pkg/subscraping/sources/chaos/chaos.go
@@ -74,8 +74,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/chinaz/chinaz.go
+++ b/pkg/subscraping/sources/chinaz/chinaz.go
@@ -91,8 +91,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/commoncrawl/commoncrawl.go
+++ b/pkg/subscraping/sources/commoncrawl/commoncrawl.go
@@ -105,8 +105,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return false
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(_ []string) {

--- a/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/pkg/subscraping/sources/crtsh/crtsh.go
@@ -200,8 +200,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return true
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return false
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(_ []string) {

--- a/pkg/subscraping/sources/digitalyama/digitalyama.go
+++ b/pkg/subscraping/sources/digitalyama/digitalyama.go
@@ -119,8 +119,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/digitorus/digitorus.go
+++ b/pkg/subscraping/sources/digitorus/digitorus.go
@@ -87,8 +87,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return true
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return false
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(_ []string) {

--- a/pkg/subscraping/sources/dnsdb/dnsdb.go
+++ b/pkg/subscraping/sources/dnsdb/dnsdb.go
@@ -183,8 +183,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return true
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
+++ b/pkg/subscraping/sources/dnsdumpster/dnsdumpster.go
@@ -91,8 +91,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/dnsrepo/dnsrepo.go
+++ b/pkg/subscraping/sources/dnsrepo/dnsrepo.go
@@ -100,8 +100,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/domainsproject/domainsproject.go
+++ b/pkg/subscraping/sources/domainsproject/domainsproject.go
@@ -117,8 +117,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/driftnet/driftnet.go
+++ b/pkg/subscraping/sources/driftnet/driftnet.go
@@ -104,9 +104,14 @@ func (s *Source) HasRecursiveSupport() bool {
 	return true
 }
 
+// KeyRequirement indicates that we need an API key
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 // NeedsKey indicates that we need an API key
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 // AddApiKeys provides us with the API key(s)

--- a/pkg/subscraping/sources/facebook/ctlogs.go
+++ b/pkg/subscraping/sources/facebook/ctlogs.go
@@ -164,9 +164,14 @@ func (s *Source) HasRecursiveSupport() bool {
 	return true
 }
 
+// KeyRequirement returns the API key requirement level for this source
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 // NeedsKey returns true if the source requires an API key
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 // AddApiKeys adds api keys to the source

--- a/pkg/subscraping/sources/fofa/fofa.go
+++ b/pkg/subscraping/sources/fofa/fofa.go
@@ -117,8 +117,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/fullhunt/fullhunt.go
+++ b/pkg/subscraping/sources/fullhunt/fullhunt.go
@@ -86,8 +86,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/github/github.go
+++ b/pkg/subscraping/sources/github/github.go
@@ -265,8 +265,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/gitlab/gitlab.go
+++ b/pkg/subscraping/sources/gitlab/gitlab.go
@@ -160,8 +160,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/hackertarget/hackertarget.go
+++ b/pkg/subscraping/sources/hackertarget/hackertarget.go
@@ -33,12 +33,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 		htSearchUrl := fmt.Sprintf("https://api.hackertarget.com/hostsearch/?q=%s", domain)
 		randomApiKey := subscraping.PickRandom(s.apiKeys, s.Name())
-		if randomApiKey == "" {
-			s.skipped = true
-			return
+		if randomApiKey != "" {
+			htSearchUrl = fmt.Sprintf("%s&apikey=%s", htSearchUrl, randomApiKey)
 		}
-
-		htSearchUrl = fmt.Sprintf("%s&apikey=%s", htSearchUrl, randomApiKey)
 
 		resp, err := session.SimpleGet(ctx, htSearchUrl)
 		if err != nil {
@@ -94,11 +91,14 @@ func (s *Source) HasRecursiveSupport() bool {
 	return true
 }
 
-func (s *Source) NeedsKey() bool {
-	return false
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.OptionalKey
 }
 
-// TODO: env variable will not work if NeedsKey is false, entire api key management needs to be refactored
+func (s *Source) NeedsKey() bool {
+	return s.KeyRequirement() == subscraping.RequiredKey
+}
+
 func (s *Source) AddApiKeys(keys []string) {
 	s.apiKeys = keys
 }

--- a/pkg/subscraping/sources/hudsonrock/hudsonrock.go
+++ b/pkg/subscraping/sources/hudsonrock/hudsonrock.go
@@ -87,8 +87,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return false
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(_ []string) {

--- a/pkg/subscraping/sources/intelx/intelx.go
+++ b/pkg/subscraping/sources/intelx/intelx.go
@@ -165,8 +165,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/leakix/leakix.go
+++ b/pkg/subscraping/sources/leakix/leakix.go
@@ -88,8 +88,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return true
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.OptionalKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/merklemap/merklemap.go
+++ b/pkg/subscraping/sources/merklemap/merklemap.go
@@ -139,8 +139,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return true
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/netlas/netlas.go
+++ b/pkg/subscraping/sources/netlas/netlas.go
@@ -184,8 +184,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/onyphe/onyphe.go
+++ b/pkg/subscraping/sources/onyphe/onyphe.go
@@ -147,8 +147,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/profundis/profundis.go
+++ b/pkg/subscraping/sources/profundis/profundis.go
@@ -109,8 +109,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/pugrecon/pugrecon.go
+++ b/pkg/subscraping/sources/pugrecon/pugrecon.go
@@ -133,9 +133,14 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+// KeyRequirement returns the API key requirement level for this source.
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 // NeedsKey returns true as this source requires an API key.
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 // AddApiKeys adds the API keys for the source.

--- a/pkg/subscraping/sources/quake/quake.go
+++ b/pkg/subscraping/sources/quake/quake.go
@@ -139,8 +139,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/rapiddns/rapiddns.go
+++ b/pkg/subscraping/sources/rapiddns/rapiddns.go
@@ -102,8 +102,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return false
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(_ []string) {

--- a/pkg/subscraping/sources/reconcloud/reconcloud.go
+++ b/pkg/subscraping/sources/reconcloud/reconcloud.go
@@ -89,8 +89,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return true
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return false
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(_ []string) {

--- a/pkg/subscraping/sources/reconeer/reconeer.go
+++ b/pkg/subscraping/sources/reconeer/reconeer.go
@@ -36,14 +36,12 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			close(results)
 		}(time.Now())
 
-		randomApiKey := subscraping.PickRandom(s.apiKeys, s.Name())
-		if randomApiKey == "" {
-			s.skipped = true
-			return
-		}
 		headers := map[string]string{
-			"Accept":    "application/json",
-			"X-API-KEY": randomApiKey,
+			"Accept": "application/json",
+		}
+		randomApiKey := subscraping.PickRandom(s.apiKeys, s.Name())
+		if randomApiKey != "" {
+			headers["X-API-KEY"] = randomApiKey
 		}
 		apiURL := fmt.Sprintf("https://www.reconeer.com/api/domain/%s", domain)
 		resp, err := session.Get(ctx, apiURL, "", headers)
@@ -92,8 +90,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.OptionalKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/redhuntlabs/redhuntlabs.go
+++ b/pkg/subscraping/sources/redhuntlabs/redhuntlabs.go
@@ -136,8 +136,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/riddler/riddler.go
+++ b/pkg/subscraping/sources/riddler/riddler.go
@@ -78,8 +78,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return false
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(_ []string) {

--- a/pkg/subscraping/sources/robtex/robtext.go
+++ b/pkg/subscraping/sources/robtex/robtext.go
@@ -131,8 +131,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/rsecloud/rsecloud.go
+++ b/pkg/subscraping/sources/rsecloud/rsecloud.go
@@ -108,8 +108,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/securitytrails/securitytrails.go
+++ b/pkg/subscraping/sources/securitytrails/securitytrails.go
@@ -142,8 +142,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return true
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/shodan/shodan.go
+++ b/pkg/subscraping/sources/shodan/shodan.go
@@ -115,8 +115,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/sitedossier/sitedossier.go
+++ b/pkg/subscraping/sources/sitedossier/sitedossier.go
@@ -97,8 +97,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return false
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(_ []string) {

--- a/pkg/subscraping/sources/thc/thc.go
+++ b/pkg/subscraping/sources/thc/thc.go
@@ -109,8 +109,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return false
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(_ []string) {

--- a/pkg/subscraping/sources/threatbook/threatbook.go
+++ b/pkg/subscraping/sources/threatbook/threatbook.go
@@ -113,8 +113,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/threatcrowd/threatcrowd.go
+++ b/pkg/subscraping/sources/threatcrowd/threatcrowd.go
@@ -108,9 +108,14 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+// KeyRequirement returns the API key requirement level for this source.
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
 // NeedsKey indicates if the source requires an API key.
 func (s *Source) NeedsKey() bool {
-	return false
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 // AddApiKeys is a no-op since ThreatCrowd does not require an API key.

--- a/pkg/subscraping/sources/threatminer/threatminer.go
+++ b/pkg/subscraping/sources/threatminer/threatminer.go
@@ -80,8 +80,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return false
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(_ []string) {

--- a/pkg/subscraping/sources/virustotal/virustotal.go
+++ b/pkg/subscraping/sources/virustotal/virustotal.go
@@ -113,8 +113,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return true
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/waybackarchive/waybackarchive.go
+++ b/pkg/subscraping/sources/waybackarchive/waybackarchive.go
@@ -84,8 +84,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return false
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(_ []string) {

--- a/pkg/subscraping/sources/whoisxmlapi/whoisxmlapi.go
+++ b/pkg/subscraping/sources/whoisxmlapi/whoisxmlapi.go
@@ -99,8 +99,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/windvane/windvane.go
+++ b/pkg/subscraping/sources/windvane/windvane.go
@@ -136,8 +136,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/sources/zoomeyeapi/zoomeyeapi.go
+++ b/pkg/subscraping/sources/zoomeyeapi/zoomeyeapi.go
@@ -118,8 +118,12 @@ func (s *Source) HasRecursiveSupport() bool {
 	return false
 }
 
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+
 func (s *Source) NeedsKey() bool {
-	return true
+	return s.KeyRequirement() == subscraping.RequiredKey
 }
 
 func (s *Source) AddApiKeys(keys []string) {

--- a/pkg/subscraping/types.go
+++ b/pkg/subscraping/types.go
@@ -33,6 +33,15 @@ type Statistics struct {
 	Skipped   bool
 }
 
+// KeyRequirement represents the API key requirement level for a source
+type KeyRequirement int
+
+const (
+	NoKey KeyRequirement = iota
+	OptionalKey
+	RequiredKey
+)
+
 // Source is an interface inherited by each passive source
 type Source interface {
 	// Run takes a domain as argument and a session object
@@ -52,7 +61,11 @@ type Source interface {
 	// not just root domains.
 	HasRecursiveSupport() bool
 
-	// NeedsKey returns true if the source requires an API key
+	// KeyRequirement returns the API key requirement level for this source
+	KeyRequirement() KeyRequirement
+
+	// NeedsKey returns true if the source requires an API key.
+	// Deprecated: Use KeyRequirement() instead for more granular control.
 	NeedsKey() bool
 
 	AddApiKeys([]string)


### PR DESCRIPTION
## Summary
- Adds `KeyRequirement` enum with three states: `NoKey`, `OptionalKey`, `RequiredKey`
- Adds `KeyRequirement()` method to Source interface
- Updates config generation to include optional sources in provider-config.yaml
- Updates env var loading to work for optional sources
- Updates source listing (`-ls`) with `~` marker for optional sources
- Marks hackertarget, leakix, reconeer as `OptionalKey`
- Fixes hackertarget and reconeer to work without API key

## Source Listing Output
```
Sources marked with an * require key(s) or token(s) to work.
Sources marked with a ~ optionally support key(s) for better results.
```

## Test Plan
- [ ] Run `subfinder -ls` and verify markers display correctly
- [ ] Test hackertarget without API key configured
- [ ] Test hackertarget with `HACKERTARGET_API_KEY` env var
- [ ] Verify provider-config.yaml includes optional sources

Closes #1695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a granular key requirement system that distinguishes between required and optional API keys, enabling sources to function with or without authentication.
  * Updated help text to clearly mark sources that require keys (*) and those that optionally support keys (~) for improved results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->