### PR TITLE
fix: revert virustotal api limit to 1000

### DIFF
--- a/pkg/subscraping/sources/virustotal/virustotal.go
+++ b/pkg/subscraping/sources/virustotal/virustotal.go
@@ -56,7 +56,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				return
 			default:
 			}
-			var url = fmt.Sprintf("https://www.virustotal.com/api/v3/domains/%s/subdomains?limit=40", domain)
+			var url = fmt.Sprintf("https://www.virustotal.com/api/v3/domains/%s/subdomains?limit=1000", domain)
 			if cursor != "" {
 				url = fmt.Sprintf("%s&cursor=%s", url, cursor)
 			}


### PR DESCRIPTION
## Summary
- Reverts the VirusTotal API limit parameter from 40 back to 1000
- The limit=40 change in #1548 caused excessive pagination requests, quickly exhausting VirusTotal's 500 request quota

## Test plan
- [ ] Test with VirusTotal API key against a domain with many subdomains
- [ ] Verify reduced number of API requests compared to limit=40

Fixes #1562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced VirusTotal subdomain enumeration to retrieve up to 1000 subdomains per request, significantly expanding subdomain discovery capabilities and providing more comprehensive enumeration results for reconnaissance activities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->