### PR TITLE
fix: mark LeakIX as requiring an API key

### DIFF
--- a/pkg/subscraping/sources/leakix/leakix.go
+++ b/pkg/subscraping/sources/leakix/leakix.go
@@ -92,7 +92,7 @@ func (s *Source) HasRecursiveSupport() bool {
 }
 
 func (s *Source) KeyRequirement() subscraping.KeyRequirement {
-	return subscraping.OptionalKey
+	return subscraping.RequiredKey
 }
 
 func (s *Source) NeedsKey() bool {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * LeakIX integration now requires an API key to function. Previously, the key was optional. Users must provide valid credentials to use this source.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->