### PR TITLE
Fix timeout flag inconsistency (#1560)

### DIFF
--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -19,15 +19,21 @@ import (
 
 // NewSession creates a new session object for a domain
 func NewSession(domain string, proxy string, multiRateLimiter *ratelimit.MultiLimiter, timeout int) (*Session, error) {
+	timeoutDuration := time.Duration(timeout) * time.Second
+	
 	Transport := &http.Transport{
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 100,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
-		Dial: (&net.Dialer{
-			Timeout: time.Duration(timeout) * time.Second,
-		}).Dial,
+		DialContext: (&net.Dialer{
+			Timeout:   timeoutDuration,
+			KeepAlive: timeoutDuration,
+		}).DialContext,
+		TLSHandshakeTimeout:   timeoutDuration,
+		ResponseHeaderTimeout: timeoutDuration,
+		ExpectContinueTimeout: 1 * time.Second,
 	}
 
 	// Add proxy
@@ -43,7 +49,7 @@ func NewSession(domain string, proxy string, multiRateLimiter *ratelimit.MultiLi
 
 	client := &http.Client{
 		Transport: Transport,
-		Timeout:   time.Duration(timeout) * time.Second,
+		Timeout:   timeoutDuration,
 	}
 
 	session := &Session{Client: client}


### PR DESCRIPTION
## Description
This PR fixes the timeout flag inconsistency issue reported in #1560 where the `-timeout` option does not work consistently across runs.

## Root Cause
The issue was caused by:
1. Use of deprecated `Dial` method instead of `DialContext`
2. Missing timeout configurations for TLS handshake and response headers
3. Lack of KeepAlive timeout which could cause connections to hang

## Changes Made
- ✅ Replaced deprecated `Dial` with `DialContext` for proper context-aware timeout handling
- ✅ Added `TLSHandshakeTimeout` to ensure TLS handshakes respect the timeout
- ✅ Added `ResponseHeaderTimeout` to prevent hanging on slow response headers
- ✅ Added `KeepAlive` timeout to the dialer to prevent connection hanging
- ✅ Added `ExpectContinueTimeout` for better HTTP/1.1 handling
- ✅ Consolidated timeout duration calculation to ensure consistency

## Testing
The fix ensures that all HTTP operations (connection, TLS handshake, response headers) respect the configured timeout value consistently across all runs.

## Related Issues
Fixes #1560
Related to #872

## Checklist
- [x] Code follows the project's coding standards
- [x] Changes are backward compatible
- [x] Commit message follows conventional commits format
- [x] No breaking changes introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved HTTP timeout handling with more granular controls for connection establishment, TLS handshakes, and response headers to enhance reliability and stability of network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->