### PR TITLE
add bgptoolkit source

### DIFF
--- a/pkg/passive/sources.go
+++ b/pkg/passive/sources.go
@@ -11,6 +11,7 @@ import (
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/alienvault"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/anubis"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/bgptoolkit"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/bevigil"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/bufferover"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/builtwith"
@@ -65,6 +66,7 @@ import (
 var AllSources = [...]subscraping.Source{
 	&alienvault.Source{},
 	&anubis.Source{},
+	&bgptoolkit.Source{},
 	&bevigil.Source{},
 	&bufferover.Source{},
 	&builtwith.Source{},

--- a/pkg/passive/sources_test.go
+++ b/pkg/passive/sources_test.go
@@ -13,6 +13,7 @@ var (
 	expectedAllSources = []string{
 		"alienvault",
 		"anubis",
+		"bgptoolkit",
 		"bevigil",
 		"bufferover",
 		"c99",
@@ -69,6 +70,7 @@ var (
 	expectedDefaultSources = []string{
 		"alienvault",
 		"anubis",
+		"bgptoolkit",
 		"bevigil",
 		"bufferover",
 		"c99",
@@ -111,6 +113,7 @@ var (
 
 	expectedDefaultRecursiveSources = []string{
 		"alienvault",
+		"bgptoolkit",
 		"bufferover",
 		"certspotter",
 		"crtsh",

--- a/pkg/subscraping/sources/bgptoolkit/bgptoolkit.go
+++ b/pkg/subscraping/sources/bgptoolkit/bgptoolkit.go
@@ -1,0 +1,120 @@
+// Package bgptoolkit logic
+package bgptoolkit
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+)
+
+type apiDomain struct {
+	Domain string `json:"domain"`
+}
+
+type apiResponse struct {
+	Domains []apiDomain `json:"domains"`
+}
+
+// Source is the passive scraping agent
+// using BGP Toolkit certificate transparency search.
+type Source struct {
+	timeTaken time.Duration
+	errors    int
+	results   int
+	requests  int
+}
+
+// Run function returns all subdomains found with the service
+func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
+	results := make(chan subscraping.Result)
+	s.errors = 0
+	s.results = 0
+	s.requests = 0
+
+	go func() {
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
+
+		endpoint := fmt.Sprintf("https://bgp.he.net/certs/api/list?domain=%s", url.QueryEscape(domain))
+		s.requests++
+		resp, err := session.SimpleGet(ctx, endpoint)
+		if err != nil {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
+			session.DiscardHTTPResponse(resp)
+			return
+		}
+
+		var data apiResponse
+		if err := jsoniter.NewDecoder(resp.Body).Decode(&data); err != nil {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
+			session.DiscardHTTPResponse(resp)
+			return
+		}
+		session.DiscardHTTPResponse(resp)
+
+		for _, entry := range data.Domains {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			for _, value := range session.Extractor.Extract(entry.Domain) {
+				if value == "" {
+					continue
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: value}:
+					s.results++
+				}
+			}
+		}
+	}()
+
+	return results
+}
+
+// Name returns the name of the source
+func (s *Source) Name() string {
+	return "bgptoolkit"
+}
+
+func (s *Source) IsDefault() bool {
+	return true
+}
+
+func (s *Source) HasRecursiveSupport() bool {
+	return true
+}
+
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
+func (s *Source) NeedsKey() bool {
+	return s.KeyRequirement() == subscraping.RequiredKey
+}
+
+func (s *Source) AddApiKeys(_ []string) {
+	// no key needed
+}
+
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		Requests:  s.requests,
+		TimeTaken: s.timeTaken,
+	}
+}


### PR DESCRIPTION
## Proposed changes

Add a new passive source `bgptoolkit` that retrieves subdomains from BGP Toolkit’s certificate search API (`/certs/api/list?domain=...`). The source is registered in `AllSources` and source list tests, and enabled by default with recursive support.

### Proof

`go test ./...`

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/subfinder/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BGP Toolkit as a new passive source for subdomain enumeration, enabled by default for all scan operations. This source retrieves subdomain intelligence through API queries and is fully integrated into the recursive subdomain discovery workflow for comprehensive domain reconnaissance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->