### PR TITLE
fix: honor -rl (global rate limit) when -rls is not set

### DIFF
--- a/pkg/passive/passive.go
+++ b/pkg/passive/passive.go
@@ -86,9 +86,9 @@ func (a *Agent) buildMultiRateLimiter(ctx context.Context, globalRateLimit int, 
 	var multiRateLimiter *ratelimit.MultiLimiter
 	var err error
 
-	global := uint(globalRateLimit)
-	if globalRateLimit < 0 {
-		global = 0
+	var global uint
+	if globalRateLimit > 0 {
+		global = uint(globalRateLimit)
 	}
 
 	for _, source := range a.sources {

--- a/pkg/passive/passive_test.go
+++ b/pkg/passive/passive_test.go
@@ -32,6 +32,10 @@ func TestBuildMultiRateLimiter(t *testing.T) {
 		mrl, err := agent.buildMultiRateLimiter(ctx, 3, customRL)
 		require.NoError(t, err)
 		require.NotNil(t, mrl)
+
+		limit, err := mrl.GetLimit("hackertarget")
+		require.NoError(t, err)
+		require.Equal(t, uint(3), limit)
 	})
 
 	t.Run("NegativeGlobalRateLimitClampsToZero", func(t *testing.T) {
@@ -48,7 +52,7 @@ func TestBuildMultiRateLimiter(t *testing.T) {
 	t.Run("UnlimitedGlobalRateLimitBehavesLikeUnlimited", func(t *testing.T) {
 		agent := New([]string{"crtsh"}, []string{}, false, false)
 
-		mrl, err := agent.buildMultiRateLimiter(ctx, math.MaxInt32, nil)
+		mrl, err := agent.buildMultiRateLimiter(ctx, int(math.MaxUint32), nil)
 		require.NoError(t, err)
 		require.NotNil(t, mrl)
 	})


### PR DESCRIPTION
Fixes #1434.

The global rate limit flag (`-rl`) was effectively ignored for sources that don't have an explicit per-source entry in `-rls`, causing subfinder to run unthrottled unless `-rls` was provided.

Changes:
- Apply `-rl` to every source by default.
- If `-rls` contains an entry for a source, it overrides the global value.
- Guard against nil custom rate limit configuration.
- Clamp negative `-rl` values to 0.

Tests:
- Add coverage for nil custom rate limit (no panic) and negative global rate limit.

/claim #1434


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-source rate limits now inherit a computed global default; per-source overrides continue to be supported.

* **Bug Fixes**
  * Negative global rate limits are clamped to zero; global default is applied only when positive.

* **Tests**
  * Added unit tests validating global-default and per-source override behavior across edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->