### PR TITLE
fix: implement rate limit (rl/rls) support per source (fixes #1434)

### DIFF
--- a/pkg/passive/passive.go
+++ b/pkg/passive/passive.go
@@ -86,13 +86,19 @@ func (a *Agent) buildMultiRateLimiter(ctx context.Context, globalRateLimit int, 
 	var multiRateLimiter *ratelimit.MultiLimiter
 	var err error
 	for _, source := range a.sources {
-		var rl uint
-		if sourceRateLimit, ok := rateLimit.Custom.Get(strings.ToLower(source.Name())); ok {
-			rl = sourceRateLimitOrDefault(uint(globalRateLimit), sourceRateLimit)
+		// Start with the global rate limit; per-source limits override it
+		rl := uint(globalRateLimit)
+		duration := time.Second
+
+		if sourceConfig, ok := rateLimit.Custom.Get(strings.ToLower(source.Name())); ok {
+			if sourceConfig.MaxCount > 0 {
+				rl = sourceConfig.MaxCount
+				duration = sourceConfig.Duration
+			}
 		}
 
 		if rl > 0 {
-			multiRateLimiter, err = addRateLimiter(ctx, multiRateLimiter, source.Name(), rl, time.Second)
+			multiRateLimiter, err = addRateLimiter(ctx, multiRateLimiter, source.Name(), rl, duration)
 		} else {
 			multiRateLimiter, err = addRateLimiter(ctx, multiRateLimiter, source.Name(), math.MaxUint32, time.Millisecond)
 		}
@@ -102,13 +108,6 @@ func (a *Agent) buildMultiRateLimiter(ctx context.Context, globalRateLimit int, 
 		}
 	}
 	return multiRateLimiter, err
-}
-
-func sourceRateLimitOrDefault(defaultRateLimit uint, sourceRateLimit uint) uint {
-	if sourceRateLimit > 0 {
-		return sourceRateLimit
-	}
-	return defaultRateLimit
 }
 
 func addRateLimiter(ctx context.Context, multiRateLimiter *ratelimit.MultiLimiter, key string, maxCount uint, duration time.Duration) (*ratelimit.MultiLimiter, error) {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -58,14 +58,17 @@ func NewRunner(options *Options) (*Runner, error) {
 
 	// Initialize the custom rate limit
 	runner.rateLimit = &subscraping.CustomRateLimit{
-		Custom: mapsutil.SyncLockMap[string, uint]{
-			Map: make(map[string]uint),
+		Custom: mapsutil.SyncLockMap[string, subscraping.RateLimitConfig]{
+			Map: make(map[string]subscraping.RateLimitConfig),
 		},
 	}
 
 	for source, sourceRateLimit := range options.RateLimits.AsMap() {
 		if sourceRateLimit.MaxCount > 0 && sourceRateLimit.MaxCount <= math.MaxUint {
-			_ = runner.rateLimit.Custom.Set(source, sourceRateLimit.MaxCount)
+			_ = runner.rateLimit.Custom.Set(source, subscraping.RateLimitConfig{
+				MaxCount: sourceRateLimit.MaxCount,
+				Duration: sourceRateLimit.Duration,
+			})
 		}
 	}
 

--- a/pkg/subscraping/types.go
+++ b/pkg/subscraping/types.go
@@ -15,8 +15,14 @@ const (
 	CtxSourceArg CtxArg = "source"
 )
 
+// RateLimitConfig holds rate limit settings (count + duration) for a source
+type RateLimitConfig struct {
+	MaxCount uint
+	Duration time.Duration
+}
+
 type CustomRateLimit struct {
-	Custom mapsutil.SyncLockMap[string, uint]
+	Custom mapsutil.SyncLockMap[string, RateLimitConfig]
 }
 
 // BasicAuth request's Authorization header


### PR DESCRIPTION
## Summary

Fixes two bugs preventing `-rl` (global rate limit) and `-rls` (per-source rate limit) options from working correctly.

### Bug 1: Global rate limit (`-rl`) was ignored

In `buildMultiRateLimiter`, `rl` was initialized to `0` and only set when a source existed in the custom rate limit map. Sources not in the map fell through to the `else` branch and got `math.MaxUint32` (unlimited), completely ignoring the `-rl` flag.

**Fix:** Initialize `rl := uint(globalRateLimit)` so the global limit applies as the default for all sources, with per-source configs overriding it.

### Bug 2: Per-source rate limit duration (`-rls`) was lost

`CustomRateLimit` stored only `uint` (the count), dropping the `time.Duration` from `goflags.RateLimit`. `buildMultiRateLimiter` then hardcoded `time.Second` for all limits. So `-rls sitedossier=8/m` was applied as 8 req/sec instead of 8 req/min — 60x too fast.

**Fix:** Added `RateLimitConfig{MaxCount uint; Duration time.Duration}` to the subscraping package, updated `CustomRateLimit` to use it, stored the duration when loading rate limits in the runner, and used the stored duration in `buildMultiRateLimiter`.

### Files Changed
- `pkg/subscraping/types.go` - Added `RateLimitConfig` struct, updated `CustomRateLimit` to store config with duration
- `pkg/runner/runner.go` - Store both count and duration from goflags when building rate limits
- `pkg/passive/passive.go` - Use global rate limit as default, respect per-source duration

/claim #1434

Closes #1434