### PR TITLE
fix: chaos repeats apex in fqdn output [#1778]

### DIFF
--- a/pkg/subscraping/sources/chaos/chaos.go
+++ b/pkg/subscraping/sources/chaos/chaos.go
@@ -3,7 +3,6 @@ package chaos
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/projectdiscovery/chaos-client/pkg/chaos"
@@ -54,8 +53,16 @@ func (s *Source) Run(ctx context.Context, domain string, _ *subscraping.Session)
 				s.errors++
 				break
 			}
+			// upstream returns domain twice sometimes #1778
+			subdomain := result.Subdomain
+			domainLen := len(domain)
+			subdomainLen := len(subdomain)
+			value := subdomain + "." + domain
+			if subdomainLen > domainLen+1 && subdomain[subdomainLen-domainLen-1] == '.' && subdomain[subdomainLen-domainLen:] == domain {
+				value = subdomain
+			}
 			results <- subscraping.Result{
-				Source: s.Name(), Type: subscraping.Subdomain, Value: fmt.Sprintf("%s.%s", result.Subdomain, domain),
+				Source: s.Name(), Type: subscraping.Subdomain, Value: value,
 			}
 			s.results++
 		}

--- a/pkg/subscraping/sources/chaos/chaos.go
+++ b/pkg/subscraping/sources/chaos/chaos.go
@@ -19,6 +19,19 @@ type Source struct {
 	skipped   bool
 }
 
+// normalizeSubdomain handles inconsistent upstream API responses where some domains
+// return full subdomains (e.g., "mail.hotmail.com") while others return just the
+// subdomain part (e.g., "mail"). #1778
+func normalizeSubdomain(subdomain, domain string) string {
+	domainLen := len(domain)
+	subdomainLen := len(subdomain)
+	value := subdomain + "." + domain
+	if subdomainLen > domainLen+1 && subdomain[subdomainLen-domainLen-1] == '.' && subdomain[subdomainLen-domainLen:] == domain {
+		value = subdomain
+	}
+	return value
+}
+
 // Run function returns all subdomains found with the service
 func (s *Source) Run(ctx context.Context, domain string, _ *subscraping.Session) <-chan subscraping.Result {
 	results := make(chan subscraping.Result)
@@ -53,14 +66,7 @@ func (s *Source) Run(ctx context.Context, domain string, _ *subscraping.Session)
 				s.errors++
 				break
 			}
-			// upstream returns domain twice sometimes #1778
-			subdomain := result.Subdomain
-			domainLen := len(domain)
-			subdomainLen := len(subdomain)
-			value := subdomain + "." + domain
-			if subdomainLen > domainLen+1 && subdomain[subdomainLen-domainLen-1] == '.' && subdomain[subdomainLen-domainLen:] == domain {
-				value = subdomain
-			}
+			value := normalizeSubdomain(result.Subdomain, domain)
 			results <- subscraping.Result{
 				Source: s.Name(), Type: subscraping.Subdomain, Value: value,
 			}

--- a/pkg/subscraping/sources/chaos/chaos.go
+++ b/pkg/subscraping/sources/chaos/chaos.go
@@ -23,6 +23,20 @@ type Source struct {
 // return full subdomains (e.g., "mail.hotmail.com") while others return just the
 // subdomain part (e.g., "mail"). #1778
 func normalizeSubdomain(subdomain, domain string) string {
+// normalizeSubdomain handles inconsistent upstream API responses where some domains
+// return full subdomains (e.g., "mail.hotmail.com") while others return just the
+// subdomain part (e.g., "mail"). #1778
+func normalizeSubdomain(subdomain, domain string) string {
+	if subdomain == domain {
+		return subdomain
+	}
+	domainLen := len(domain)
+	subdomainLen := len(subdomain)
+	if subdomainLen > domainLen+1 && subdomain[subdomainLen-domainLen-1] == '.' && subdomain[subdomainLen-domainLen:] == domain {
+		return subdomain
+	}
+	return subdomain + "." + domain
+}
 	domainLen := len(domain)
 	subdomainLen := len(subdomain)
 	value := subdomain + "." + domain

--- a/pkg/subscraping/sources/chaos/chaos_test.go
+++ b/pkg/subscraping/sources/chaos/chaos_test.go
@@ -1,0 +1,63 @@
+package chaos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeSubdomain(t *testing.T) {
+	tests := []struct {
+		name      string
+		subdomain string
+		domain    string
+		expected  string
+	}{
+		{
+			name:      "subdomain part only",
+			subdomain: "mail",
+			domain:    "hotmail.com",
+			expected:  "mail.hotmail.com",
+		},
+		{
+			name:      "full subdomain - upstream returns domain twice #1778",
+			subdomain: "mail.hotmail.com",
+			domain:    "hotmail.com",
+			expected:  "mail.hotmail.com",
+		},
+		{
+			name:      "nested subdomain with domain already present",
+			subdomain: "api.mail.hotmail.com",
+			domain:    "hotmail.com",
+			expected:  "api.mail.hotmail.com",
+		},
+		{
+			name:      "subdomain with dot but not ending with domain",
+			subdomain: "api.mail",
+			domain:    "hotmail.com",
+			expected:  "api.mail.hotmail.com",
+		},
+		{
+			name:      "single char subdomain",
+			subdomain: "a",
+			domain:    "hotmail.com",
+			expected:  "a.hotmail.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeSubdomain(tt.subdomain, tt.domain)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestChaosSource_Metadata(t *testing.T) {
+	source := &Source{}
+
+	assert.Equal(t, "chaos", source.Name())
+	assert.True(t, source.IsDefault())
+	assert.False(t, source.HasRecursiveSupport())
+	assert.True(t, source.NeedsKey())
+}

--- a/pkg/subscraping/sources/chaos/chaos_test.go
+++ b/pkg/subscraping/sources/chaos/chaos_test.go
@@ -13,8 +13,14 @@ func TestNormalizeSubdomain(t *testing.T) {
 		domain    string
 		expected  string
 	}{
+  {
+   name:      "subdomain equals domain - apex returned as-is",
+   subdomain: "hotmail.com",
+   domain:    "hotmail.com",
+   expected:  "hotmail.com",
+  },
 		{
-			name:      "subdomain part only",
+		 name:      "subdomain part only",
 			subdomain: "mail",
 			domain:    "hotmail.com",
 			expected:  "mail.hotmail.com",


### PR DESCRIPTION
## Proposed changes

Check if fqdn returned ends with the entry domain before its appended; avoid duplication.

### Proof

see #1778; checkout test. 

## Checklist

- [uhu] Pull request is created against the [dev](https://github.com/projectdiscovery/subfinder/tree/dev) branch
- [def] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [yep] I have added tests that prove my fix is effective or that my feature works
- [see issue] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subdomain normalization in the Chaos source so upstream variants are consistently returned as fully qualified domain names, avoiding duplicates or missing domain labels.

* **Tests**
  * Added tests covering subdomain normalization edge cases and validating Chaos source metadata (name, default status, recursion support, and key requirement).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->