### PR TITLE
fix source leaks

### DIFF
--- a/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/pkg/subscraping/sources/crtsh/crtsh.go
@@ -93,6 +93,7 @@ func (s *Source) getSubdomainsFromSQL(ctx context.Context, domain string, sessio
 		s.errors++
 		return 0
 	}
+	defer rows.Close() //nolint:errcheck
 	if err := rows.Err(); err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 		s.errors++

--- a/pkg/subscraping/sources/github/github.go
+++ b/pkg/subscraping/sources/github/github.go
@@ -107,6 +107,7 @@ func (s *Source) enumerate(ctx context.Context, searchURL string, domainRegexp *
 		session.DiscardHTTPResponse(resp)
 
 		s.enumerate(ctx, searchURL, domainRegexp, tokens, session, results)
+		return
 	}
 
 	var data response


### PR DESCRIPTION
crtsh now closes its db cursor and the github source returns after the rate-limit retry instead of decoding a discarded body

Closes #1800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of database query results to help prevent resource leaks.
  * Fixed GitHub enumeration behavior so rate-limit responses are handled more reliably and processing stops correctly after a retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->