### PR TITLE
fix(subscraping): cap untrusted source response bodies with a size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ DEBUG:
   -ls, -list-sources  list all available sources
 
 OPTIMIZATION:
-  -timeout int   seconds to wait before timing out (default 30)
-  -max-time int  minutes to wait for enumeration results (default 10)
+  -timeout int                  seconds to wait before timing out (default 30)
+  -max-time int                 minutes to wait for enumeration results (default 10)
+  -rsr, -response-size-read int max response body size to read in bytes from passive sources (0 = unlimited)
 ```
 
 ## Environment Variables

--- a/pkg/passive/passive.go
+++ b/pkg/passive/passive.go
@@ -15,8 +15,9 @@ import (
 )
 
 type EnumerationOptions struct {
-	customRateLimiter *subscraping.CustomRateLimit
-	maxResults        int
+	customRateLimiter   *subscraping.CustomRateLimit
+	maxResults          int
+	maxResponseBodySize int64
 }
 
 type EnumerateOption func(opts *EnumerationOptions)
@@ -33,6 +34,14 @@ func WithCustomRateLimit(crl *subscraping.CustomRateLimit) EnumerateOption {
 func WithMaxResults(maxResults int) EnumerateOption {
 	return func(opts *EnumerationOptions) {
 		opts.maxResults = maxResults
+	}
+}
+
+// WithMaxResponseBodySize sets a cap on bytes read from passive-source HTTP
+// response bodies. A value of 0 (the default) means no limit.
+func WithMaxResponseBodySize(maxResponseBodySize int64) EnumerateOption {
+	return func(opts *EnumerationOptions) {
+		opts.maxResponseBodySize = maxResponseBodySize
 	}
 }
 
@@ -69,6 +78,7 @@ func (a *Agent) EnumerateSubdomainsWithCtx(ctx context.Context, domain string, p
 		}
 		defer session.Close()
 		session.MaxResults = enumerateOptions.maxResults
+		session.MaxResponseBodySize = enumerateOptions.maxResponseBodySize
 
 		ctx, cancel := context.WithTimeout(ctx, maxEnumTime)
 

--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -50,7 +50,7 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 
 	// Run the passive subdomain enumeration
 	now := time.Now()
-	passiveResults := r.passiveAgent.EnumerateSubdomainsWithCtx(ctx, domain, r.options.Proxy, r.options.RateLimit, r.options.Timeout, time.Duration(r.options.MaxEnumerationTime)*time.Minute, passive.WithCustomRateLimit(r.rateLimit), passive.WithMaxResults(r.options.MaxResults))
+	passiveResults := r.passiveAgent.EnumerateSubdomainsWithCtx(ctx, domain, r.options.Proxy, r.options.RateLimit, r.options.Timeout, time.Duration(r.options.MaxEnumerationTime)*time.Minute, passive.WithCustomRateLimit(r.rateLimit), passive.WithMaxResults(r.options.MaxResults), passive.WithMaxResponseBodySize(int64(r.options.MaxResponseBodySize)))
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -74,6 +74,11 @@ type Options struct {
 	// A value of 0 (default) means no limit. Only sources that paginate
 	// honor this (currently virustotal), to help stay within API quotas.
 	MaxResults int `yaml:"max-results,omitempty"`
+
+	// MaxResponseBodySize limits bytes read from passive-source HTTP response
+	// bodies. A value of 0 (default) means no limit. When set, oversized bodies
+	// are truncated to protect against unbounded memory use.
+	MaxResponseBodySize int `yaml:"response-size-read,omitempty"`
 }
 
 // OnResultCallback (hostResult)
@@ -148,6 +153,7 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("optimization", "Optimization",
 		flagSet.IntVar(&options.Timeout, "timeout", 30, "seconds to wait before timing out"),
 		flagSet.IntVar(&options.MaxEnumerationTime, "max-time", 10, "minutes to wait for enumeration results"),
+		flagSet.IntVarP(&options.MaxResponseBodySize, "response-size-read", "rsr", 0, "max response body size to read in bytes from passive sources (0 = unlimited)"),
 	)
 
 	if err := flagSet.Parse(); err != nil {

--- a/pkg/runner/validate.go
+++ b/pkg/runner/validate.go
@@ -45,6 +45,11 @@ func (options *Options) validateOptions() error {
 		return fmt.Errorf("max-results cannot be negative")
 	}
 
+	// The response body size limit cannot be negative.
+	if options.MaxResponseBodySize < 0 {
+		return fmt.Errorf("response-size-read cannot be negative")
+	}
+
 	if options.Match != nil {
 		options.matchRegexes = make([]*regexp.Regexp, len(options.Match))
 		var err error

--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -17,19 +17,8 @@ import (
 	"github.com/projectdiscovery/gologger"
 )
 
-// maxResponseBodySize is the maximum number of bytes read from an untrusted
-// passive-source HTTP response body. Sources consume third-party (and in some
-// cases MITM-able, since TLS verification is skipped) responses; without a cap
-// a malicious/compromised upstream can stream an effectively unbounded body and
-// OOM the process, because the HTTP client Timeout bounds time, not size.
-//
-// 50MB is intentionally generous: legitimate subdomain lists — even large
-// certificate-transparency or bulk-API JSON responses — sit well under this,
-// so real sources are unaffected while pathological bodies are truncated.
-const maxResponseBodySize = 50 * 1024 * 1024 // 50MB
-
-// limitedResponseBody wraps a response body so that at most maxResponseBodySize
-// bytes can be read from it, while still closing the underlying body (so no
+// limitedResponseBody wraps a response body so that at most maxSize bytes can
+// be read from it, while still closing the underlying body (so no
 // connection/body leak). It is applied centrally so every source inherits the
 // cap regardless of how it consumes the body (io.ReadAll, json.Decoder,
 // bufio.Scanner, etc.).
@@ -38,16 +27,17 @@ type limitedResponseBody struct {
 	io.Closer // the original body's Close
 }
 
-// LimitResponseBody caps response.Body at maxResponseBodySize bytes in place.
-// It is idempotent-safe to call and preserves the original body's Close.
+// LimitResponseBody caps response.Body at maxSize bytes in place when maxSize
+// is greater than zero. A maxSize of 0 or less leaves the body unchanged
+// (unlimited; the default). It preserves the original body's Close.
 // Exported so sources that (rarely) issue a raw client.Do — bypassing the
 // session's httpRequestWrapper — can opt into the same protection.
-func LimitResponseBody(response *http.Response) {
-	if response == nil || response.Body == nil {
+func LimitResponseBody(response *http.Response, maxSize int64) {
+	if response == nil || response.Body == nil || maxSize <= 0 {
 		return
 	}
 	response.Body = &limitedResponseBody{
-		Reader: io.LimitReader(response.Body, maxResponseBodySize),
+		Reader: io.LimitReader(response.Body, maxSize),
 		Closer: response.Body,
 	}
 }
@@ -143,7 +133,7 @@ func (s *Session) HTTPRequest(ctx context.Context, method, requestURL, cookies s
 		return nil, mrlErr
 	}
 
-	return httpRequestWrapper(s.Client, req)
+	return httpRequestWrapper(s.Client, req, s.MaxResponseBodySize)
 }
 
 // DiscardHTTPResponse discards the response content by demand
@@ -166,15 +156,15 @@ func (s *Session) Close() {
 	s.Client.CloseIdleConnections()
 }
 
-func httpRequestWrapper(client *http.Client, request *http.Request) (*http.Response, error) {
+func httpRequestWrapper(client *http.Client, request *http.Request, maxResponseBodySize int64) (*http.Response, error) {
 	response, err := client.Do(request)
 	if err != nil {
 		return nil, err
 	}
 
-	// Cap the untrusted response body centrally so every source (and the
-	// debug-logging path below) is bounded regardless of how it reads the body.
-	LimitResponseBody(response)
+	// Optionally cap the untrusted response body centrally so every source
+	// (and the debug-logging path below) inherits the same bound when enabled.
+	LimitResponseBody(response, maxResponseBodySize)
 
 	if response.StatusCode != http.StatusOK {
 		requestURL, _ := url.QueryUnescape(request.URL.String())

--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -17,6 +17,41 @@ import (
 	"github.com/projectdiscovery/gologger"
 )
 
+// maxResponseBodySize is the maximum number of bytes read from an untrusted
+// passive-source HTTP response body. Sources consume third-party (and in some
+// cases MITM-able, since TLS verification is skipped) responses; without a cap
+// a malicious/compromised upstream can stream an effectively unbounded body and
+// OOM the process, because the HTTP client Timeout bounds time, not size.
+//
+// 50MB is intentionally generous: legitimate subdomain lists — even large
+// certificate-transparency or bulk-API JSON responses — sit well under this,
+// so real sources are unaffected while pathological bodies are truncated.
+const maxResponseBodySize = 50 * 1024 * 1024 // 50MB
+
+// limitedResponseBody wraps a response body so that at most maxResponseBodySize
+// bytes can be read from it, while still closing the underlying body (so no
+// connection/body leak). It is applied centrally so every source inherits the
+// cap regardless of how it consumes the body (io.ReadAll, json.Decoder,
+// bufio.Scanner, etc.).
+type limitedResponseBody struct {
+	io.Reader // io.LimitReader over the original body
+	io.Closer // the original body's Close
+}
+
+// LimitResponseBody caps response.Body at maxResponseBodySize bytes in place.
+// It is idempotent-safe to call and preserves the original body's Close.
+// Exported so sources that (rarely) issue a raw client.Do — bypassing the
+// session's httpRequestWrapper — can opt into the same protection.
+func LimitResponseBody(response *http.Response) {
+	if response == nil || response.Body == nil {
+		return
+	}
+	response.Body = &limitedResponseBody{
+		Reader: io.LimitReader(response.Body, maxResponseBodySize),
+		Closer: response.Body,
+	}
+}
+
 // NewSession creates a new session object for a domain
 func NewSession(domain string, proxy string, multiRateLimiter *ratelimit.MultiLimiter, timeout int) (*Session, error) {
 	Transport := &http.Transport{
@@ -136,6 +171,10 @@ func httpRequestWrapper(client *http.Client, request *http.Request) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
+
+	// Cap the untrusted response body centrally so every source (and the
+	// debug-logging path below) is bounded regardless of how it reads the body.
+	LimitResponseBody(response)
 
 	if response.StatusCode != http.StatusOK {
 		requestURL, _ := url.QueryUnescape(request.URL.String())

--- a/pkg/subscraping/agent_test.go
+++ b/pkg/subscraping/agent_test.go
@@ -1,0 +1,132 @@
+package subscraping
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// trackedBody records whether Close was called, so we can prove the size cap
+// wrapper still closes the underlying body (no connection/body leak).
+type trackedBody struct {
+	io.Reader
+	closed bool
+}
+
+func (t *trackedBody) Close() error {
+	t.closed = true
+	return nil
+}
+
+// TestLimitResponseBody_CapsOversizedBody verifies the central cap truncates a
+// body larger than maxResponseBodySize while still delegating Close to the
+// original body.
+func TestLimitResponseBody_CapsOversizedBody(t *testing.T) {
+	orig := &trackedBody{Reader: newInfiniteReader()}
+	resp := &http.Response{Body: orig}
+
+	LimitResponseBody(resp)
+
+	// Reading everything from the (now capped) body must stop at the limit
+	// rather than streaming forever.
+	n, err := io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, int64(maxResponseBodySize), n, "body must be truncated to the cap")
+
+	require.NoError(t, resp.Body.Close())
+	assert.True(t, orig.closed, "Close must propagate to the original body (no leak)")
+}
+
+// TestLimitResponseBody_SmallBodyUntouched verifies that a legitimate small
+// body is passed through unchanged.
+func TestLimitResponseBody_SmallBodyUntouched(t *testing.T) {
+	const payload = "sub1.example.com\nsub2.example.com\n"
+	orig := &trackedBody{Reader: newStringReader(payload)}
+	resp := &http.Response{Body: orig}
+
+	LimitResponseBody(resp)
+
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(data))
+
+	require.NoError(t, resp.Body.Close())
+	assert.True(t, orig.closed)
+}
+
+// TestLimitResponseBody_NilSafe verifies the helper tolerates a nil response or
+// nil body without panicking.
+func TestLimitResponseBody_NilSafe(t *testing.T) {
+	assert.NotPanics(t, func() { LimitResponseBody(nil) })
+	assert.NotPanics(t, func() { LimitResponseBody(&http.Response{}) })
+}
+
+// TestHTTPRequestWrapper_CapsResponseBody exercises the full session path
+// (client.Do -> httpRequestWrapper) and proves the returned response body is
+// bounded even when the server tries to stream far more than the cap.
+func TestHTTPRequestWrapper_CapsResponseBody(t *testing.T) {
+	// Server writes maxResponseBodySize+overflow bytes; the client must only be
+	// able to read up to the cap.
+	const overflow = 4096
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		buf := make([]byte, 64*1024)
+		remaining := maxResponseBodySize + overflow
+		for remaining > 0 {
+			chunk := len(buf)
+			if remaining < chunk {
+				chunk = remaining
+			}
+			nw, werr := w.Write(buf[:chunk])
+			if werr != nil {
+				return
+			}
+			remaining -= nw
+		}
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := httpRequestWrapper(server.Client(), req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	n, err := io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, int64(maxResponseBodySize), n, "wrapper must cap the body at maxResponseBodySize")
+}
+
+// --- small helpers (avoid pulling in strings/bytes just for the readers) ---
+
+type infiniteReader struct{}
+
+func (infiniteReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'a'
+	}
+	return len(p), nil
+}
+
+func newInfiniteReader() io.Reader { return infiniteReader{} }
+
+func newStringReader(s string) io.Reader { return &stringReader{data: s} }
+
+type stringReader struct {
+	data string
+	pos  int
+}
+
+func (s *stringReader) Read(p []byte) (int, error) {
+	if s.pos >= len(s.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, s.data[s.pos:])
+	s.pos += n
+	return n, nil
+}

--- a/pkg/subscraping/agent_test.go
+++ b/pkg/subscraping/agent_test.go
@@ -1,6 +1,7 @@
 package subscraping
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const testMaxResponseBodySize int64 = 64 * 1024 // 64KB — small enough for fast tests
 
 // trackedBody records whether Close was called, so we can prove the size cap
 // wrapper still closes the underlying body (no connection/body leak).
@@ -23,32 +26,31 @@ func (t *trackedBody) Close() error {
 }
 
 // TestLimitResponseBody_CapsOversizedBody verifies the central cap truncates a
-// body larger than maxResponseBodySize while still delegating Close to the
-// original body.
+// body larger than maxSize while still delegating Close to the original body.
 func TestLimitResponseBody_CapsOversizedBody(t *testing.T) {
 	orig := &trackedBody{Reader: newInfiniteReader()}
 	resp := &http.Response{Body: orig}
 
-	LimitResponseBody(resp)
+	LimitResponseBody(resp, testMaxResponseBodySize)
 
 	// Reading everything from the (now capped) body must stop at the limit
 	// rather than streaming forever.
 	n, err := io.Copy(io.Discard, resp.Body)
 	require.NoError(t, err)
-	assert.Equal(t, int64(maxResponseBodySize), n, "body must be truncated to the cap")
+	assert.Equal(t, testMaxResponseBodySize, n, "body must be truncated to the cap")
 
 	require.NoError(t, resp.Body.Close())
 	assert.True(t, orig.closed, "Close must propagate to the original body (no leak)")
 }
 
 // TestLimitResponseBody_SmallBodyUntouched verifies that a legitimate small
-// body is passed through unchanged.
+// body is passed through unchanged when a cap is set.
 func TestLimitResponseBody_SmallBodyUntouched(t *testing.T) {
 	const payload = "sub1.example.com\nsub2.example.com\n"
 	orig := &trackedBody{Reader: newStringReader(payload)}
 	resp := &http.Response{Body: orig}
 
-	LimitResponseBody(resp)
+	LimitResponseBody(resp, testMaxResponseBodySize)
 
 	data, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -58,24 +60,39 @@ func TestLimitResponseBody_SmallBodyUntouched(t *testing.T) {
 	assert.True(t, orig.closed)
 }
 
+// TestLimitResponseBody_ZeroIsUnlimited verifies that maxSize <= 0 leaves the
+// body uncapped (default product behavior).
+func TestLimitResponseBody_ZeroIsUnlimited(t *testing.T) {
+	const payload = "sub1.example.com\n"
+	orig := &trackedBody{Reader: newStringReader(payload)}
+	resp := &http.Response{Body: orig}
+
+	LimitResponseBody(resp, 0)
+
+	// Body must be the original closer (not wrapped).
+	require.Equal(t, orig, resp.Body)
+
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(data))
+}
+
 // TestLimitResponseBody_NilSafe verifies the helper tolerates a nil response or
 // nil body without panicking.
 func TestLimitResponseBody_NilSafe(t *testing.T) {
-	assert.NotPanics(t, func() { LimitResponseBody(nil) })
-	assert.NotPanics(t, func() { LimitResponseBody(&http.Response{}) })
+	assert.NotPanics(t, func() { LimitResponseBody(nil, testMaxResponseBodySize) })
+	assert.NotPanics(t, func() { LimitResponseBody(&http.Response{}, testMaxResponseBodySize) })
 }
 
 // TestHTTPRequestWrapper_CapsResponseBody exercises the full session path
 // (client.Do -> httpRequestWrapper) and proves the returned response body is
-// bounded even when the server tries to stream far more than the cap.
+// bounded when a positive limit is configured.
 func TestHTTPRequestWrapper_CapsResponseBody(t *testing.T) {
-	// Server writes maxResponseBodySize+overflow bytes; the client must only be
-	// able to read up to the cap.
 	const overflow = 4096
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		buf := make([]byte, 64*1024)
-		remaining := maxResponseBodySize + overflow
+		buf := make([]byte, 1024)
+		remaining := int(testMaxResponseBodySize) + overflow
 		for remaining > 0 {
 			chunk := len(buf)
 			if remaining < chunk {
@@ -90,16 +107,38 @@ func TestHTTPRequestWrapper_CapsResponseBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
 	require.NoError(t, err)
 
-	resp, err := httpRequestWrapper(server.Client(), req)
+	resp, err := httpRequestWrapper(server.Client(), req, testMaxResponseBodySize)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 
 	n, err := io.Copy(io.Discard, resp.Body)
 	require.NoError(t, err)
-	assert.Equal(t, int64(maxResponseBodySize), n, "wrapper must cap the body at maxResponseBodySize")
+	assert.Equal(t, testMaxResponseBodySize, n, "wrapper must cap the body when limit is set")
+}
+
+// TestHTTPRequestWrapper_UnlimitedByDefault verifies that a zero limit leaves
+// the body readable beyond any artificial small cap.
+func TestHTTPRequestWrapper_UnlimitedByDefault(t *testing.T) {
+	const bodySize = 8 * 1024
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(make([]byte, bodySize))
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := httpRequestWrapper(server.Client(), req, 0)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	n, err := io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, int64(bodySize), n, "wrapper must not cap the body when limit is 0")
 }
 
 // --- small helpers (avoid pulling in strings/bytes just for the readers) ---

--- a/pkg/subscraping/sources/threatcrowd/threatcrowd.go
+++ b/pkg/subscraping/sources/threatcrowd/threatcrowd.go
@@ -55,8 +55,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 		// This source issues a raw client.Do (bypassing the session's
-		// httpRequestWrapper), so apply the response-body size cap explicitly.
-		subscraping.LimitResponseBody(resp)
+		// httpRequestWrapper), so apply the response-body size cap explicitly
+		// when configured (0 = unlimited).
+		subscraping.LimitResponseBody(resp, session.MaxResponseBodySize)
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}

--- a/pkg/subscraping/sources/threatcrowd/threatcrowd.go
+++ b/pkg/subscraping/sources/threatcrowd/threatcrowd.go
@@ -54,6 +54,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			s.errors++
 			return
 		}
+		// This source issues a raw client.Do (bypassing the session's
+		// httpRequestWrapper), so apply the response-body size cap explicitly.
+		subscraping.LimitResponseBody(resp)
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}

--- a/pkg/subscraping/types.go
+++ b/pkg/subscraping/types.go
@@ -97,6 +97,11 @@ type Session struct {
 	// Sources that paginate can honor this to avoid unnecessary requests
 	// (e.g. to stay within API quotas).
 	MaxResults int
+	// MaxResponseBodySize is the maximum number of bytes read from a
+	// passive-source HTTP response body. A value of 0 means no limit
+	// (default behavior). When set, bodies are truncated via LimitReader
+	// so a malicious or oversized upstream cannot OOM the process.
+	MaxResponseBodySize int64
 }
 
 // Result is a result structure returned by a source


### PR DESCRIPTION
### Summary
Passive-source HTTP responses were read with unbounded `io.ReadAll(resp.Body)` (and `json.Decoder` / `bufio.Scanner`) across the source implementations. A malicious, compromised, or MITM'd upstream API returning a very large body can drive the process to OOM — the client timeout bounds time, not size (and `NewSession` sets `InsecureSkipVerify: true`).

This caps response bodies centrally at the session layer so every source inherits the limit regardless of how it reads the body.

### Changes
- `pkg/subscraping/agent.go`: added `maxResponseBodySize = 50 * 1024 * 1024` (50MB) and a `LimitResponseBody` helper that wraps `resp.Body` in an `io.LimitReader` while preserving `Close`. Applied in the shared `httpRequestWrapper` (covers `Get` / `SimpleGet` / `Post` / `SimplePost` / `HTTPRequest`).
- `pkg/subscraping/sources/threatcrowd/threatcrowd.go`: applied the same helper to its raw `session.Client.Do` call, which bypasses the wrapper.
- `pkg/subscraping/agent_test.go`: unit tests for the cap (oversized body truncated, small body untouched, nil-safe, Close propagation).

50MB is generous enough that legitimate large subdomain lists are unaffected. No timeout, concurrency, or source logic changed.

### Testing
`go build ./...` and `go test ./pkg/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional maximum response-size limit for passive HTTP enumeration.
  * Added `--response-size-read` / `-rsr` configuration, with unlimited reading by default.
  * Invalid negative size limits are rejected.
  * Response bodies remain safely closable when limits are applied.

* **Bug Fixes**
  * Prevented oversized or continuously streamed responses from consuming excessive resources.
  * Applied response-size protection to ThreatCrowd data retrieval.

* **Documentation**
  * Documented the new response-size setting and command-line options.

* **Tests**
  * Added coverage for capped, uncapped, small, nil, and streamed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->