### PR TITLE
feat(sources): honor -max-results across paginating sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ CONFIGURATION:
   -nW, -active                  display active subdomains only
   -proxy string                 http proxy to use with subfinder
   -ei, -exclude-ip              exclude IPs from the list of domains
-  -mr, -max-results int         limit the number of results per source (0 = unlimited; honored by paginating sources such as virustotal)
+  -mr, -max-results int         limit the number of results per source (0 = unlimited; honored by paginating sources)
 
 DEBUG:
   -silent             show only subdomains in output

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -71,8 +71,8 @@ type Options struct {
 	DisableUpdateCheck bool             // DisableUpdateCheck disable update checking
 
 	// MaxResults limits the number of results requested per source.
-	// A value of 0 (default) means no limit. Only sources that paginate
-	// honor this (currently virustotal), to help stay within API quotas.
+	// A value of 0 (default) means no limit. Sources that paginate honor this
+	// by stopping early once the limit is reached, to help stay within API quotas.
 	MaxResults int `yaml:"max-results,omitempty"`
 }
 
@@ -133,7 +133,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.RemoveWildcard, "active", "nW", false, "display active subdomains only"),
 		flagSet.StringVar(&options.Proxy, "proxy", "", "http proxy to use with subfinder"),
 		flagSet.BoolVarP(&options.ExcludeIps, "exclude-ip", "ei", false, "exclude IPs from the list of domains"),
-		flagSet.IntVarP(&options.MaxResults, "max-results", "mr", 0, "limit the number of results per source (0 = unlimited; honored by paginating sources such as virustotal)"),
+		flagSet.IntVarP(&options.MaxResults, "max-results", "mr", 0, "limit the number of results per source (0 = unlimited; honored by paginating sources)"),
 	)
 
 	flagSet.CreateGroup("debug", "Debug",

--- a/pkg/subscraping/sources/censys/censys.go
+++ b/pkg/subscraping/sources/censys/censys.go
@@ -102,6 +102,10 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
+		// Honor an optional per-source result limit (0 = no limit) so a single
+		// domain can't drain an API quota by paginating to the end.
+		maxResults := session.MaxResults
+
 		apiURL := baseURL + searchEndpoint
 		cursor := ""
 		currentPage := 1
@@ -172,6 +176,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 						return
 					case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: name}:
 						s.results++
+					}
+					if maxResults > 0 && s.results >= maxResults {
+						return
 					}
 				}
 			}

--- a/pkg/subscraping/sources/censys/censys_maxresults_test.go
+++ b/pkg/subscraping/sources/censys/censys_maxresults_test.go
@@ -1,0 +1,109 @@
+package censys
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rewriteTransport sends every request to the test server while preserving the
+// original path/query, so the source's hardcoded api.platform.censys.io URL
+// still reaches our handler.
+type rewriteTransport struct {
+	target *url.URL
+}
+
+func (r *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = r.target.Scheme
+	req.URL.Host = r.target.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func newTestSession(t *testing.T, server *httptest.Server, maxResults int) *subscraping.Session {
+	t.Helper()
+	target, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	return &subscraping.Session{
+		Client:           &http.Client{Transport: &rewriteTransport{target: target}, Timeout: 5 * time.Second},
+		MultiRateLimiter: createTestMultiRateLimiter(context.Background()),
+		MaxResults:       maxResults,
+	}
+}
+
+func runCensys(t *testing.T, source *Source, session *subscraping.Session, domain string) (subs []string, errs []error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctxWithValue := context.WithValue(ctx, subscraping.CtxSourceArg, "censys")
+
+	for r := range source.Run(ctxWithValue, domain, session) {
+		switch r.Type {
+		case subscraping.Subdomain:
+			subs = append(subs, r.Value)
+		case subscraping.Error:
+			errs = append(errs, r.Error)
+		}
+	}
+	return
+}
+
+// With no per-source limit the source follows the page token until it is empty
+// and returns every subdomain, so paid keys are never silently truncated.
+func TestCensysSource_FollowsPagesWhenUnlimited(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		// Two pages of one name each, then the page token terminates.
+		if n < 2 {
+			_, _ = fmt.Fprintf(w, `{"result":{"hits":[{"certificate_v1":{"resource":{"names":["sub%d.example.com"]}}}],"next_page_token":"next-%d"}}`, n, n)
+			return
+		}
+		_, _ = fmt.Fprintf(w, `{"result":{"hits":[{"certificate_v1":{"resource":{"names":["sub%d.example.com"]}}}],"next_page_token":""}}`, n)
+	}))
+	defer server.Close()
+
+	source := &Source{}
+	source.AddApiKeys([]string{"test_pat:test_org"})
+
+	subs, errs := runCensys(t, source, newTestSession(t, server, 0), "example.com")
+
+	assert.Empty(t, errs)
+	assert.ElementsMatch(t, []string{"sub1.example.com", "sub2.example.com"}, subs)
+	assert.Equal(t, 2, source.Statistics().Requests)
+}
+
+// When -max-results (session.MaxResults) is set, pagination must stop as soon
+// as the limit is reached so a single domain can't drain an API quota.
+func TestCensysSource_MaxResultsCapsPagination(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		// Always return one name plus a non-empty page token so the source would
+		// keep paginating (up to maxCensysPages) without the max-results cap.
+		_, _ = fmt.Fprintf(w, `{"result":{"hits":[{"certificate_v1":{"resource":{"names":["sub%d.example.com"]}}}],"next_page_token":"next-%d"}}`, n, n)
+	}))
+	defer server.Close()
+
+	const limit = 3
+	source := &Source{}
+	source.AddApiKeys([]string{"test_pat:test_org"})
+
+	subs, errs := runCensys(t, source, newTestSession(t, server, limit), "example.com")
+
+	assert.Empty(t, errs, "no errors expected on the happy path")
+	assert.Len(t, subs, limit, "should yield exactly max-results subdomains")
+	assert.Equal(t, limit, source.Statistics().Requests, "request count must be capped by max-results")
+	assert.Equal(t, int32(limit), atomic.LoadInt32(&hits))
+}

--- a/pkg/subscraping/sources/certspotter/certspotter.go
+++ b/pkg/subscraping/sources/certspotter/certspotter.go
@@ -45,6 +45,10 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
+		// Honor an optional per-source result limit (0 = no limit) so a single
+		// domain can't drain an API quota by paginating to the end.
+		maxResults := session.MaxResults
+
 		headers := map[string]string{"Authorization": "Bearer " + randomApiKey}
 		cookies := ""
 
@@ -74,6 +78,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 					return
 				case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}:
 					s.results++
+				}
+				if maxResults > 0 && s.results >= maxResults {
+					return
 				}
 			}
 		}
@@ -120,6 +127,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 						return
 					case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}:
 						s.results++
+					}
+					if maxResults > 0 && s.results >= maxResults {
+						return
 					}
 				}
 			}

--- a/pkg/subscraping/sources/certspotter/certspotter_test.go
+++ b/pkg/subscraping/sources/certspotter/certspotter_test.go
@@ -1,0 +1,147 @@
+package certspotter
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/ratelimit"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rewriteTransport sends every request to the test server while preserving the
+// original path/query, so the source's hardcoded api.certspotter.com URL still
+// reaches our handler.
+type rewriteTransport struct {
+	target *url.URL
+}
+
+func (r *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = r.target.Scheme
+	req.URL.Host = r.target.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func newTestSession(t *testing.T, server *httptest.Server, maxResults int) *subscraping.Session {
+	t.Helper()
+	target, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	mrl, err := ratelimit.NewMultiLimiter(context.Background(), &ratelimit.Options{
+		Key:         "certspotter",
+		IsUnlimited: false,
+		MaxCount:    math.MaxInt32,
+		Duration:    time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	return &subscraping.Session{
+		Client:           &http.Client{Transport: &rewriteTransport{target: target}, Timeout: 5 * time.Second},
+		MultiRateLimiter: mrl,
+		MaxResults:       maxResults,
+	}
+}
+
+func runSource(t *testing.T, source *Source, session *subscraping.Session, domain string) (subs []string, errs []error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctxWithValue := context.WithValue(ctx, subscraping.CtxSourceArg, "certspotter")
+
+	for r := range source.Run(ctxWithValue, domain, session) {
+		switch r.Type {
+		case subscraping.Subdomain:
+			subs = append(subs, r.Value)
+		case subscraping.Error:
+			errs = append(errs, r.Error)
+		}
+	}
+	return
+}
+
+func TestCertspotterSource_Metadata(t *testing.T) {
+	source := &Source{}
+	assert.Equal(t, "certspotter", source.Name())
+	assert.True(t, source.IsDefault())
+	assert.True(t, source.HasRecursiveSupport())
+	assert.True(t, source.NeedsKey())
+}
+
+func TestCertspotterSource_NoApiKey(t *testing.T) {
+	source := &Source{}
+
+	ctx := context.Background()
+	mrl, _ := ratelimit.NewMultiLimiter(ctx, &ratelimit.Options{
+		Key:         "certspotter",
+		IsUnlimited: false,
+		MaxCount:    math.MaxInt32,
+		Duration:    time.Millisecond,
+	})
+	session := &subscraping.Session{Client: http.DefaultClient, MultiRateLimiter: mrl}
+	ctxWithValue := context.WithValue(ctx, subscraping.CtxSourceArg, "certspotter")
+
+	var count int
+	for range source.Run(ctxWithValue, "example.com", session) {
+		count++
+	}
+	assert.Equal(t, 0, count, "expected no results without an api key")
+	assert.True(t, source.Statistics().Skipped)
+}
+
+// With no per-source limit the source walks the "after" cursor to the end and
+// returns every subdomain, i.e. the default behaviour stays unbounded.
+func TestCertspotterSource_FollowsCursorWhenUnlimited(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		// Two issuances, then an empty page terminates pagination.
+		if n < 3 {
+			_, _ = fmt.Fprintf(w, `[{"id":"%d","dns_names":["sub%d.example.com"]}]`, n, n)
+			return
+		}
+		_, _ = fmt.Fprint(w, `[]`)
+	}))
+	defer server.Close()
+
+	source := &Source{}
+	source.AddApiKeys([]string{"test-key"})
+
+	subs, errs := runSource(t, source, newTestSession(t, server, 0), "example.com")
+
+	assert.Empty(t, errs)
+	assert.ElementsMatch(t, []string{"sub1.example.com", "sub2.example.com"}, subs)
+}
+
+// When -max-results (session.MaxResults) is set, pagination must stop as soon
+// as the limit is reached so a single domain can't drain an API quota.
+func TestCertspotterSource_MaxResultsCapsPagination(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		// Always return one issuance with a fresh id so the source would paginate
+		// forever via the "after" cursor without the max-results cap.
+		_, _ = fmt.Fprintf(w, `[{"id":"%d","dns_names":["sub%d.example.com"]}]`, n, n)
+	}))
+	defer server.Close()
+
+	const limit = 3
+	source := &Source{}
+	source.AddApiKeys([]string{"test-key"})
+
+	subs, errs := runSource(t, source, newTestSession(t, server, limit), "example.com")
+
+	assert.Empty(t, errs, "no errors expected on the happy path")
+	assert.Len(t, subs, limit, "should yield exactly max-results subdomains")
+	assert.Equal(t, limit, source.Statistics().Requests, "request count must be capped by max-results")
+	assert.Equal(t, int32(limit), atomic.LoadInt32(&hits))
+}

--- a/pkg/subscraping/sources/commoncrawl/commoncrawl.go
+++ b/pkg/subscraping/sources/commoncrawl/commoncrawl.go
@@ -130,6 +130,9 @@ func (s *Source) Statistics() subscraping.Statistics {
 }
 
 func (s *Source) getSubdomains(ctx context.Context, searchURL, domain string, session *subscraping.Session, results chan subscraping.Result) bool {
+	// Honor an optional per-source result limit (0 = no limit) so a single
+	// domain can't trigger scanning every index to the end.
+	maxResults := session.MaxResults
 	for {
 		select {
 		case <-ctx.Done():
@@ -170,6 +173,10 @@ func (s *Source) getSubdomains(ctx context.Context, searchURL, domain string, se
 							return false
 						case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}:
 							s.results++
+						}
+						if maxResults > 0 && s.results >= maxResults {
+							session.DiscardHTTPResponse(resp)
+							return false
 						}
 					}
 				}

--- a/pkg/subscraping/sources/dnsdb/dnsdb.go
+++ b/pkg/subscraping/sources/dnsdb/dnsdb.go
@@ -67,6 +67,10 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
+		// Honor an optional per-source result limit (0 = no limit) so a single
+		// domain can't drain an API quota by paginating to the end.
+		maxResults := session.MaxResults
+
 		headers := map[string]string{
 			"X-API-KEY": randomApiKey,
 			"Accept":    "application/x-ndjson",
@@ -141,6 +145,10 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 							return
 						case results <- subscraping.Result{Source: sourceName, Type: subscraping.Subdomain, Value: strings.TrimSuffix(response.Obj.Name, ".")}:
 							s.results++
+						}
+						if maxResults > 0 && s.results >= uint64(maxResults) {
+							session.DiscardHTTPResponse(resp)
+							return
 						}
 					}
 				} else if respCond != "begin" {

--- a/pkg/subscraping/sources/merklemap/merklemap.go
+++ b/pkg/subscraping/sources/merklemap/merklemap.go
@@ -65,6 +65,10 @@ func (s *Source) fetchAllPages(ctx context.Context, domain string, headers map[s
 	totalCount := math.MaxInt
 	processedResults := 0
 
+	// Honor an optional per-source result limit (0 = no limit) so a single
+	// domain can't drain an API quota by paginating to the end.
+	maxResults := session.MaxResults
+
 	// Iterate through all pages
 	for page := 0; processedResults < totalCount; page++ {
 		pageResp, err := s.fetchPage(ctx, baseURL, page, headers, session)
@@ -90,6 +94,9 @@ func (s *Source) fetchAllPages(ctx context.Context, domain string, headers map[s
 			}
 			s.results++
 			processedResults++
+			if maxResults > 0 && s.results >= maxResults {
+				return
+			}
 		}
 
 	}

--- a/pkg/subscraping/sources/onyphe/onyphe.go
+++ b/pkg/subscraping/sources/onyphe/onyphe.go
@@ -100,14 +100,19 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 			session.DiscardHTTPResponse(resp)
 
-			// emit sends a subdomain and reports whether the per-source result
-			// limit has been reached, so callers can stop paginating early.
-			emit := func(subdomain string) (capped bool) {
+			// emit sends a subdomain and reports whether the caller should stop:
+			// either because the context was cancelled or because the per-source
+			// result limit has been reached.
+			emit := func(subdomain string) (stop bool) {
 				if subdomain == "" {
 					return false
 				}
-				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
-				s.results++
+				select {
+				case <-ctx.Done():
+					return true
+				case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}:
+					s.results++
+				}
 				return maxResults > 0 && s.results >= maxResults
 			}
 

--- a/pkg/subscraping/sources/onyphe/onyphe.go
+++ b/pkg/subscraping/sources/onyphe/onyphe.go
@@ -59,6 +59,10 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
+		// Honor an optional per-source result limit (0 = no limit) so a single
+		// domain can't drain an API quota by paginating to the end.
+		maxResults := session.MaxResults
+
 		headers := map[string]string{"Content-Type": "application/json", "Authorization": "bearer " + randomApiKey}
 
 		page := 1
@@ -96,6 +100,17 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 
 			session.DiscardHTTPResponse(resp)
 
+			// emit sends a subdomain and reports whether the per-source result
+			// limit has been reached, so callers can stop paginating early.
+			emit := func(subdomain string) (capped bool) {
+				if subdomain == "" {
+					return false
+				}
+				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
+				s.results++
+				return maxResults > 0 && s.results >= maxResults
+			}
+
 			for _, record := range respOnyphe.Results {
 				select {
 				case <-ctx.Done():
@@ -103,25 +118,18 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				default:
 				}
 				for _, subdomain := range record.Subdomains {
-					if subdomain != "" {
-						results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
-						s.results++
+					if emit(subdomain) {
+						return
 					}
 				}
-
-				if record.Hostname != "" {
-					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: record.Hostname}
-					s.results++
+				if emit(record.Hostname) {
+					return
 				}
-
-				if record.Forward != "" {
-					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: record.Forward}
-					s.results++
+				if emit(record.Forward) {
+					return
 				}
-
-				if record.Reverse != "" {
-					results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: record.Reverse}
-					s.results++
+				if emit(record.Reverse) {
+					return
 				}
 			}
 

--- a/pkg/subscraping/sources/quake/quake.go
+++ b/pkg/subscraping/sources/quake/quake.go
@@ -59,6 +59,10 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
+		// Honor an optional per-source result limit (0 = no limit) so a single
+		// domain can't drain an API quota by paginating to the end.
+		maxResults := session.MaxResults
+
 		// quake api doc https://quake.360.cn/quake/#/help
 		var pageSize = 500
 		var start = 0
@@ -116,6 +120,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				}
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 				s.results++
+				if maxResults > 0 && s.results >= maxResults {
+					return
+				}
 			}
 
 			if len(response.Data) == 0 || start+pageSize >= totalResults {

--- a/pkg/subscraping/sources/redhuntlabs/redhuntlabs.go
+++ b/pkg/subscraping/sources/redhuntlabs/redhuntlabs.go
@@ -50,6 +50,10 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
+		// Honor an optional per-source result limit (0 = no limit) so a single
+		// domain can't drain an API quota by paginating to the end.
+		maxResults := session.MaxResults
+
 		randomApiInfo := strings.Split(randomApiKey, ":")
 		if len(randomApiInfo) != 3 {
 			s.skipped = true
@@ -111,6 +115,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 					case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}:
 						s.results++
 					}
+					if maxResults > 0 && s.results >= maxResults {
+						return
+					}
 				}
 			}
 		} else {
@@ -120,6 +127,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 					return
 				case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}:
 					s.results++
+				}
+				if maxResults > 0 && s.results >= maxResults {
+					return
 				}
 			}
 		}

--- a/pkg/subscraping/sources/rsecloud/rsecloud.go
+++ b/pkg/subscraping/sources/rsecloud/rsecloud.go
@@ -47,6 +47,10 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
+		// Honor an optional per-source result limit (0 = no limit) so a single
+		// domain can't drain an API quota by paginating to the end.
+		maxResults := session.MaxResults
+
 		headers := map[string]string{"Content-Type": "application/json", "X-API-Key": randomApiKey}
 
 		fetchSubdomains := func(endpoint string) {
@@ -82,6 +86,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 					case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}:
 						s.results++
 					}
+					if maxResults > 0 && s.results >= maxResults {
+						return
+					}
 				}
 
 				if page >= rseCloudResponse.TotalPages {
@@ -92,6 +99,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		}
 
 		fetchSubdomains("active")
+		if maxResults > 0 && s.results >= maxResults {
+			return
+		}
 		fetchSubdomains("passive")
 	}()
 

--- a/pkg/subscraping/sources/securitytrails/securitytrails.go
+++ b/pkg/subscraping/sources/securitytrails/securitytrails.go
@@ -54,6 +54,10 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
+		// Honor an optional per-source result limit (0 = no limit) so a single
+		// domain can't drain an API quota by paginating to the end.
+		maxResults := session.MaxResults
+
 		var scrollId string
 		headers := map[string]string{"Content-Type": "application/json", "APIKEY": randomApiKey}
 
@@ -106,6 +110,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: record.Hostname}:
 					s.results++
 				}
+				if maxResults > 0 && s.results >= maxResults {
+					return
+				}
 			}
 
 			for _, subdomain := range securityTrailsResponse.Subdomains {
@@ -121,6 +128,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				}
 				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}
 				s.results++
+				if maxResults > 0 && s.results >= maxResults {
+					return
+				}
 			}
 
 			scrollId = securityTrailsResponse.Meta.ScrollID

--- a/pkg/subscraping/sources/shodan/shodan.go
+++ b/pkg/subscraping/sources/shodan/shodan.go
@@ -48,6 +48,10 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
+		// Honor an optional per-source result limit (0 = no limit) so a single
+		// domain can't drain an API quota by paginating to the end.
+		maxResults := session.MaxResults
+
 		page := 1
 		for {
 			select {
@@ -95,6 +99,9 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 					Source: s.Name(), Type: subscraping.Subdomain, Value: value,
 				}
 				s.results++
+				if maxResults > 0 && s.results >= maxResults {
+					return
+				}
 			}
 
 			if !response.More {

--- a/pkg/subscraping/sources/urlscan/urlscan.go
+++ b/pkg/subscraping/sources/urlscan/urlscan.go
@@ -83,6 +83,10 @@ func (s *Source) enumerate(ctx context.Context, domain string, headers map[strin
 	var searchAfter string
 	currentPage := 0
 
+	// Honor an optional per-source result limit (0 = no limit) so a single
+	// domain can't drain an API quota by paginating to the end.
+	maxResults := session.MaxResults
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -148,6 +152,9 @@ func (s *Source) enumerate(ctx context.Context, domain string, headers map[strin
 						return
 					case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}:
 						s.results++
+					}
+					if maxResults > 0 && s.results >= maxResults {
+						return
 					}
 				}
 			}


### PR DESCRIPTION
### Summary

`-max-results` (`-mr`) is currently honored only by the `virustotal` source. Every other paginating source keeps walking its cursor/pages to the end and burns API quota even when the user explicitly asked for a cap.

This applies the same early-stop pattern already used by `virustotal` to the rest of the paginating sources: once `session.MaxResults` results have been emitted, the source returns instead of requesting the next page.

### Sources updated

`censys`, `certspotter`, `shodan`, `securitytrails`, `quake`, `dnsdb`, `onyphe`, `rsecloud`, `redhuntlabs`, `urlscan`, `merklemap`, `commoncrawl`.

Single-request sources are unaffected (there is nothing to paginate).

### Behavior

- `0` (default) means unlimited — existing behavior is unchanged, paid keys are never silently truncated.
- With a positive value, pagination stops as soon as the limit is reached, bounding both results and request count.

### Tests

Added `httptest`-based coverage for `censys` and `certspotter` proving that the cap stops pagination and bounds the number of requests, following the existing `virustotal` test pattern. Also updated the flag help text and README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent `max-results` enforcement across multiple subdomain discovery sources.
  * Scraping now stops early (including pagination) once the configured maximum is reached, reducing extra requests.
  * A value of `0` continues to mean unlimited results.
* **Documentation**
  * Updated CLI help and README guidance to clarify how limits interact with pagination and early stopping.
* **Tests**
  * Added/expanded tests to verify both unlimited retrieval and early-stop behavior when limits are applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->