### PR TITLE
fix(extractor): match the target domain literally and reject partial hosts

### DIFF
--- a/pkg/subscraping/extractor.go
+++ b/pkg/subscraping/extractor.go
@@ -13,7 +13,10 @@ type RegexSubdomainExtractor struct {
 // NewSubdomainExtractor creates a new regular expression to extract
 // subdomains from text based on the given domain.
 func NewSubdomainExtractor(domain string) (*RegexSubdomainExtractor, error) {
-	extractor, err := regexp.Compile(`(?i)[a-zA-Z0-9\*_.-]+\.` + domain)
+	// QuoteMeta escapes the domain so its dots (and any other metacharacters)
+	// are matched literally. Without this, "example.com" also matches text like
+	// "exampleXcom" because "." means "any character" in a regex.
+	extractor, err := regexp.Compile(`(?i)[a-zA-Z0-9\*_.-]+\.` + regexp.QuoteMeta(domain))
 	if err != nil {
 		return nil, err
 	}
@@ -22,9 +25,42 @@ func NewSubdomainExtractor(domain string) (*RegexSubdomainExtractor, error) {
 
 // Extract implements the SubdomainExtractor interface, using the regex to find subdomains in the given text.
 func (re *RegexSubdomainExtractor) Extract(text string) []string {
-	matches := re.extractor.FindAllString(text, -1)
-	for i, match := range matches {
-		matches[i] = strings.ToLower(match)
+	indices := re.extractor.FindAllStringIndex(text, -1)
+	matches := make([]string, 0, len(indices))
+	for _, idx := range indices {
+		// Skip matches that are only a prefix of a longer hostname, e.g.
+		// "foo.example.com" found inside "foo.example.com.evil.org": these end at
+		// the target domain but the host actually belongs to a different apex.
+		if hostnameContinues(text, idx[1]) {
+			continue
+		}
+		matches = append(matches, strings.ToLower(text[idx[0]:idx[1]]))
 	}
 	return matches
+}
+
+// hostnameContinues reports whether the hostname at the given end index extends
+// further in text, i.e. the match is not a complete host. A single trailing dot
+// (the FQDN form "host.") is tolerated, but an additional label such as the
+// ".evil.org" in "foo.example.com.evil.org" is treated as a continuation.
+func hostnameContinues(text string, end int) bool {
+	if end >= len(text) {
+		return false
+	}
+	b := text[end]
+	if isLabelByte(b) {
+		return true
+	}
+	if b == '.' {
+		return end+1 < len(text) && isLabelStart(text[end+1])
+	}
+	return false
+}
+
+func isLabelByte(b byte) bool {
+	return isLabelStart(b) || b == '-' || b == '_'
+}
+
+func isLabelStart(b byte) bool {
+	return b >= 'a' && b <= 'z' || b >= 'A' && b <= 'Z' || b >= '0' && b <= '9'
 }

--- a/pkg/subscraping/extractor.go
+++ b/pkg/subscraping/extractor.go
@@ -34,7 +34,10 @@ func (re *RegexSubdomainExtractor) Extract(text string) []string {
 		if hostnameContinues(text, idx[1]) {
 			continue
 		}
-		matches = append(matches, strings.ToLower(text[idx[0]:idx[1]]))
+		// Clone so the short subdomain doesn't keep the whole (potentially large)
+		// text backing array alive: strings.ToLower returns the input unchanged
+		// when it is already lowercase, which is the common case for hostnames.
+		matches = append(matches, strings.Clone(strings.ToLower(text[idx[0]:idx[1]])))
 	}
 	return matches
 }

--- a/pkg/subscraping/extractor_test.go
+++ b/pkg/subscraping/extractor_test.go
@@ -1,0 +1,86 @@
+package subscraping
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegexSubdomainExtractor_Extract(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain string
+		text   string
+		want   []string
+	}{
+		{
+			name:   "simple subdomain",
+			domain: "example.com",
+			text:   "www.example.com",
+			want:   []string{"www.example.com"},
+		},
+		{
+			name:   "multi-level subdomain",
+			domain: "example.com",
+			text:   "a.b.c.example.com",
+			want:   []string{"a.b.c.example.com"},
+		},
+		{
+			name:   "case is normalized to lower",
+			domain: "example.com",
+			text:   "WWW.Example.COM",
+			want:   []string{"www.example.com"},
+		},
+		{
+			name:   "wildcard prefix is preserved",
+			domain: "example.com",
+			text:   "*.example.com",
+			want:   []string{"*.example.com"},
+		},
+		{
+			name:   "multiple subdomains in one blob",
+			domain: "example.com",
+			text:   "foo.example.com\nbar.example.com",
+			want:   []string{"foo.example.com", "bar.example.com"},
+		},
+		{
+			name:   "trailing dot (FQDN form) is kept",
+			domain: "example.com",
+			text:   "host.example.com.",
+			want:   []string{"host.example.com"},
+		},
+		{
+			// The dot in the domain must be literal: "example.com" must not match
+			// "exampleXcom". Before escaping the domain, the regex "." matched any
+			// character and produced this false positive.
+			name:   "domain dots are literal, not wildcards",
+			domain: "example.com",
+			text:   "sub.exampleXcom",
+			want:   nil,
+		},
+		{
+			// A host that merely ends with the target domain but belongs to a
+			// different apex must not be reported.
+			name:   "domain as a prefix of another apex is rejected",
+			domain: "example.com",
+			text:   "foo.example.com.evil.org",
+			want:   nil,
+		},
+		{
+			name:   "longer label ending in domain is rejected",
+			domain: "example.com",
+			text:   "notexample.com",
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extractor, err := NewSubdomainExtractor(tt.domain)
+			require.NoError(t, err)
+			got := extractor.Extract(tt.text)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
### Summary

`NewSubdomainExtractor` builds its regex by interpolating the raw domain:

```go
regexp.Compile(`(?i)[a-zA-Z0-9\*_.-]+\.` + domain)
```

This has two problems:

1. **Dots in the domain are treated as "any character".** For `example.com` the regex also matches text like `exampleXcom`, producing false positives.
2. **The match is unbounded on the right.** Text such as `foo.example.com.evil.org` yields the bogus subdomain `foo.example.com`, which then passes the runner's `HasSuffix("."+domain)` check and reaches the output.

This affects every source that extracts hosts from free text (`crtsh`, `waybackarchive`, `commoncrawl`, `hackertarget`, `digitorus`, `rapiddns`, `urlscan`, `sitedossier`, ...).

### Fix

- Escape the domain with `regexp.QuoteMeta` so its dots (and any other metacharacters) match literally.
- Drop matches that are only a prefix of a longer hostname, while still accepting the trailing-dot FQDN form (`host.example.com.`).

### Tests

Added table-driven tests for the extractor covering literal dots, right-boundary rejection, wildcards, trailing dots, and case-insensitivity. The package had no extractor test before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subdomain extraction accuracy, including correct handling of domains with special characters.
  * Reduced false positives by tightening hostname boundary matching and rejecting mismatched apex/overlong label patterns.
  * Ensured consistent lowercasing of extracted subdomains, with correct behavior for wildcards and trailing-dot FQDNs.
* **Tests**
  * Added unit tests covering domain matching, case normalization, wildcard preservation, trailing-dot handling, and false-positive scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->