### PR TITLE
fix(anubis): switch subdomain API to anubisdb.com

### DIFF
--- a/pkg/passive/sources_wo_auth_test.go
+++ b/pkg/passive/sources_wo_auth_test.go
@@ -32,7 +32,7 @@ func TestSourcesWithoutKeys(t *testing.T) {
 		"alienvault",     // 503 Service Temporarily Unavailable
 		"digitorus",      // failing with "Failed to retrieve certificate"
 		"dnsdumpster",    // failing with "unexpected status code 403 received"
-		"anubis",         // failing with "too many redirects"
+		"anubis",         // previously failed on jonlu.ca (Cloudflare 403 / redirects); endpoint moved to anubisdb.com
 		"threatcrowd",    // failing with "randomly failing with unmarshal error when hit multiple times"
 		"leakix",         // now requires API key (returns 401)
 		"reconeer",       // now requires API key (returns 401)

--- a/pkg/subscraping/sources/anubis/anubis.go
+++ b/pkg/subscraping/sources/anubis/anubis.go
@@ -34,7 +34,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 		}(time.Now())
 
 		s.requests++
-		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://jonlu.ca/anubis/subdomains/%s", domain))
+		resp, err := session.SimpleGet(ctx, fmt.Sprintf("https://anubisdb.com/anubis/subdomains/%s", domain))
 		if err != nil {
 			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 			s.errors++


### PR DESCRIPTION
## Summary
The Anubis source was calling `https://jonlu.ca/anubis/subdomains/:domain`, which now returns Cloudflare 403 and yields zero results.

This switches it to `https://anubisdb.com/anubis/subdomains/:domain` (same API shape, confirmed returning results for sample domains).

Fixes #1808

## Test plan
- [x] `go build ./pkg/subscraping/sources/anubis/`
- [x] Live smoke: `GET https://anubisdb.com/anubis/subdomains/hackerone.com` returns 200 with subdomain JSON
- [x] Live compare: `GET https://jonlu.ca/anubis/subdomains/tesla.com` returns 403
- [ ] Manual: `echo tesla.com | subfinder -s anubis -stats -v` returns subdomains again


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Anubis data source to use its new endpoint, restoring subdomain lookups after the previous endpoint became unavailable.
  * Preserved existing response handling and error reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->