### PR TITLE
fix: prevent panic from unsafe type assertion in context value

### DIFF
--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -102,7 +102,10 @@ func (s *Session) HTTPRequest(ctx context.Context, method, requestURL, cookies s
 		req.Header.Set(key, value)
 	}
 
-	sourceName := ctx.Value(CtxSourceArg).(string)
+	sourceName, ok := ctx.Value(CtxSourceArg).(string)
+	if !ok {
+		return nil, fmt.Errorf("missing or invalid source name in context")
+	}
 	mrlErr := s.MultiRateLimiter.Take(sourceName)
 	if mrlErr != nil {
 		return nil, mrlErr


### PR DESCRIPTION
## Summary

Fix unsafe type assertion in `pkg/subscraping/agent.go` that can cause runtime panic.

## Problem

Line 105 performs an unsafe type assertion:
```go
sourceName := ctx.Value(CtxSourceArg).(string)
```

If the context value is nil or not a string, this will panic and crash the entire process. This is particularly dangerous because:
1. Context values can be missing if not properly propagated
2. Type mismatches can occur during refactoring
3. This runs in a concurrent environment where panics affect all goroutines

## Fix

Replace with safe type assertion that returns an error instead of panicking:
```go
sourceName, ok := ctx.Value(CtxSourceArg).(string)
if !ok {
    return nil, fmt.Errorf("missing or invalid source name in context")
}
```

This allows the caller to handle the error gracefully and provides better debugging information.

## Checklist

- [x] Single-focused change
- [x] No conflicting open PRs found
- [x] Local environment limitations, relying on CI/CD automated testing

I apologize for any inconvenience and appreciate the maintainers' time reviewing this contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling when required source information is missing or invalid.
  * Prevented unexpected runtime crashes during rate-limited requests.
  * Requests now return a clear error message when the source name cannot be identified, enabling more predictable failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->