### PR TITLE
fix lint issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/rs/xid v1.5.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
-	golang.org/x/exp v0.0.0-20260112195511-716be5621a96
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -96,6 +95,7 @@ require (
 	go.etcd.io/bbolt v1.3.7 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/pkg/passive/sources.go
+++ b/pkg/passive/sources.go
@@ -2,10 +2,10 @@ package passive
 
 import (
 	"fmt"
+	"maps"
 	"os"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
@@ -180,7 +180,7 @@ func New(sourceNames, excludedSourceNames []string, useAllSources, useSourcesSup
 		gologger.Fatal().Msg("No sources selected for this search")
 	}
 
-	gologger.Debug().Msgf("Selected source(s) for this search: %s", strings.Join(maps.Keys(sources), ", "))
+	gologger.Debug().Msgf("Selected source(s) for this search: %s", strings.Join(slices.Sorted(maps.Keys(sources)), ", "))
 
 	for _, currentSource := range sources {
 		if warning, ok := sourceWarnings.Get(strings.ToLower(currentSource.Name())); ok {
@@ -198,7 +198,7 @@ func New(sourceNames, excludedSourceNames []string, useAllSources, useSourcesSup
 	}
 
 	// Create the agent, insert the sources and remove the excluded sources
-	agent := &Agent{sources: maps.Values(sources)}
+	agent := &Agent{sources: slices.Collect(maps.Values(sources))}
 
 	return agent
 }

--- a/pkg/passive/sources_test.go
+++ b/pkg/passive/sources_test.go
@@ -2,11 +2,12 @@ package passive
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/maps"
 )
 
 var (
@@ -146,7 +147,7 @@ func TestSourceCategorization(t *testing.T) {
 
 	assert.ElementsMatch(t, expectedDefaultSources, defaultSources)
 	assert.ElementsMatch(t, expectedDefaultRecursiveSources, recursiveSources)
-	assert.ElementsMatch(t, expectedAllSources, maps.Keys(NameSourceMap))
+	assert.ElementsMatch(t, expectedAllSources, slices.Collect(maps.Keys(NameSourceMap)))
 }
 
 // Review: not sure if this test is necessary/useful

--- a/pkg/passive/sources_wo_auth_test.go
+++ b/pkg/passive/sources_wo_auth_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/slices"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/gologger/levels"

--- a/pkg/runner/stats.go
+++ b/pkg/runner/stats.go
@@ -2,19 +2,18 @@ package runner
 
 import (
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
-	"golang.org/x/exp/maps"
 )
 
 func printStatistics(stats map[string]subscraping.Statistics) {
 
-	sources := maps.Keys(stats)
-	sort.Strings(sources)
+	sources := slices.Sorted(maps.Keys(stats))
 
 	var lines []string
 	var skipped []string


### PR DESCRIPTION
Replace deprecated `golang.org/x/exp/maps` and `golang.org/x/exp/slices` with the stdlib `maps` and `slices`, fixing the `govet` inline errors reported by golangci-lint v2.12.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal handling of source and statistics lists to use built-in functionality, with no change to user-facing behavior.
  * Standardized ordering in debug and statistics output for more consistent results.
* **Chores**
  * Cleaned up dependency usage by moving an experimental library to indirect-only use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->