### PR TITLE
Fix Docker Build - Bump to min go version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,14 +35,14 @@ updates:
 #    labels:
 #      - "Type: Maintenance"
 #
-#  # Maintain dependencies for docker
-#  - package-ecosystem: "docker"
-#    directory: "/"
-#    schedule:
-#      interval: "weekly"
-#    target-branch: "dev"
-#    commit-message:
-#      prefix: "chore"
-#      include: "scope"
-#    labels:
-#      - "Type: Maintenance"
+  # Maintain dependencies for docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "Type: Maintenance"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build
-FROM golang:1.24-alpine AS build-env
+FROM golang:1.25-alpine AS build-env
 RUN apk add build-base
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
## Proposed changes

Docker Build for release failed:
https://github.com/projectdiscovery/subfinder/issues/1803

https://github.com/projectdiscovery/subfinder/actions/runs/31022544058/job/92362675741

Quickly bumped the go version of the base image.

Also reenable dependabot for docker, not sure why it was disabled.

### Proof

```
docker build -t local/subfinder .
```

works, failed on dev

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/subfinder/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)