### PR TITLE
fix(crtsh): remove statement_timeout from connection string

### DIFF
--- a/pkg/subscraping/sources/crtsh/crtsh.go
+++ b/pkg/subscraping/sources/crtsh/crtsh.go
@@ -56,9 +56,7 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 }
 
 func (s *Source) getSubdomainsFromSQL(ctx context.Context, domain string, session *subscraping.Session, results chan subscraping.Result) int {
-	// connect_timeout: limits connection establishment time (in seconds)
-	// statement_timeout: limits query execution time (in milliseconds)
-	connStr := fmt.Sprintf("host=crt.sh user=guest dbname=certwatch sslmode=disable binary_parameters=yes connect_timeout=%d statement_timeout=%d", session.Timeout, session.Timeout*1000)
+	connStr := fmt.Sprintf("host=crt.sh user=guest dbname=certwatch sslmode=disable binary_parameters=yes connect_timeout=%d", session.Timeout)
 	db, err := sql.Open("postgres", connStr)
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
@@ -71,6 +69,14 @@ func (s *Source) getSubdomainsFromSQL(ctx context.Context, domain string, sessio
 			gologger.Warning().Msgf("Could not close database connection: %s\n", closeErr)
 		}
 	}()
+
+	if session.Timeout > 0 {
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("SET statement_timeout = %d", session.Timeout*1000)); err != nil {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
+			return 0
+		}
+	}
 
 	limitClause := ""
 	if all, ok := ctx.Value(contextutil.ContextArg("All")).(contextutil.ContextArg); ok {


### PR DESCRIPTION
﻿## Summary

crt.sh runs behind PgBouncer, which rejects `statement_timeout` as an
unknown startup parameter. This breaks the crtsh SQL path entirely.

The HTTP fallback is unreliable — sometimes it returns results (slowly),
sometimes crt.sh returns 404 and subfinder gets nothing. Either way, the
SQL path is broken.

The fix removes `statement_timeout` from the connection string and sends
it as a `SET` query after connecting. `connect_timeout` stays in the
connection string since lib/pq handles it client-side.

Also adds `binary_parameters=yes` which PgBouncer requires.

Fixes #1828

## Proof

The SQL path always fails. The HTTP fallback is inconsistent, so there are two scenarios:

**Option 1: Before — the HTTP fallback does not work (0 results):**

```
$ subfinder -d hackerone.com -s crtsh -v
[WRN] Encountered an error with source crtsh: pq: unsupported startup parameter: statement_timeout
[WRN] Encountered an error with source crtsh: unexpected status code 404 received from https://crt.sh/?q=%.hackerone.com&output=json
[INF] Found 0 subdomains for hackerone.com in 15 seconds
```

**Option 2: Before — HTTP fallback works, slower than the SQL path:**

```
$ subfinder -d hackerone.com -s crtsh -v
[WRN] Encountered an error with source crtsh: pq: unsupported startup parameter: statement_timeout
[INF] Found 14 subdomains for hackerone.com in 25 seconds
```

**After (this fix — SQL works):**

```
$ subfinder -d hackerone.com -s crtsh -v
[crtsh] api.hackerone.com
[crtsh] docs.hackerone.com
[crtsh] support.hackerone.com
[crtsh] www.hackerone.com
...
[INF] Found 14 subdomains for hackerone.com in 2 seconds
```

SQL path works. No errors. Consistent results.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/subfinder/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate) - not needed

