### PR TITLE
fix(subscraping): use DialContext instead of the deprecated Dial

### DIFF
--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -50,9 +50,9 @@ func NewSession(domain string, proxy string, multiRateLimiter *ratelimit.MultiLi
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout: time.Duration(timeout) * time.Second,
-		}).Dial,
+		}).DialContext,
 	}
 
 	// Add proxy


### PR DESCRIPTION
## Proposed changes

`golangci-lint` reports one issue on `dev`:

```
pkg/subscraping/agent.go:53:3: SA1019: (net/http.Transport).Dial has been deprecated since Go 1.7:
Use DialContext instead, which allows the transport to cancel dials as soon as they are no longer
needed. If both are set, DialContext takes priority. (staticcheck)
```

`Test Builds` declares `needs: [lint]`, so that single finding fails the lint job and **skips the
build, test, race-condition and example steps on every pull request**. The effect is that PRs show a
red check with no green signal behind them, and the test suite does not run in CI at all.

`DialContext` is the documented replacement and takes priority when both are set, so behaviour is
unchanged.

## Proof

Reproducible on an unmodified checkout:

```console
$ git clone --depth 1 --branch dev https://github.com/projectdiscovery/subfinder.git
$ cd subfinder && golangci-lint run
pkg/subscraping/agent.go:53:3: SA1019: ...
1 issues: staticcheck: 1
```

With this change:

```console
$ golangci-lint run
0 issues.
$ go build ./... && go test ./pkg/...
ok
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/subfinder/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

No test added: this is a two-line deprecation fix, and `golangci-lint` in CI is the check that
proves it.

I noticed this while working on an unrelated PR (#1834) whose lint job inherits the same finding.
Sending it separately rather than folding it in there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling while preserving configured connection timeouts.
  * Replaced a deprecated networking mechanism to support more reliable HTTP connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->