### PR TITLE
feat: add crtname passive source

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -5,6 +5,7 @@ Subfinder leverages multiple open APIs, it is developed for individuals to help 
 - Bufferover:  https://tls.bufferover.run
 - CommonCrawl: https://commoncrawl.org/terms-of-use/full
 - certspotter: https://sslmate.com/terms
+- crt.name: https://crt.name/
 - dnsdumpster: https://hackertarget.com/terms
 - Google Transparency: https://policies.google.com/terms
 - Alienvault: https://www.alienvault.com/terms/website-terms-of-use07may2018

--- a/pkg/passive/sources.go
+++ b/pkg/passive/sources.go
@@ -20,6 +20,7 @@ import (
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/chaos"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/chinaz"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/commoncrawl"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/crtname"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/crtsh"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/digitalyama"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/digitorus"
@@ -76,6 +77,7 @@ var AllSources = [...]subscraping.Source{
 	&chaos.Source{},
 	&chinaz.Source{},
 	&commoncrawl.Source{},
+	&crtname.Source{},
 	&crtsh.Source{},
 	&digitalyama.Source{},
 	&digitorus.Source{},

--- a/pkg/passive/sources_test.go
+++ b/pkg/passive/sources_test.go
@@ -22,6 +22,7 @@ var (
 		"chaos",
 		"chinaz",
 		"commoncrawl",
+		"crtname",
 		"crtsh",
 		"digitorus",
 		"dnsdumpster",
@@ -79,6 +80,7 @@ var (
 		"censys",
 		"chaos",
 		"chinaz",
+		"crtname",
 		"crtsh",
 		"digitorus",
 		"dnsdumpster",
@@ -159,6 +161,7 @@ func TestSourceFiltering(t *testing.T) {
 	someSources := []string{
 		"alienvault",
 		"chaos",
+		"crtname",
 		"crtsh",
 		"virustotal",
 	}

--- a/pkg/subscraping/sources/crtname/crtname.go
+++ b/pkg/subscraping/sources/crtname/crtname.go
@@ -1,0 +1,131 @@
+// Package crtname logic
+package crtname
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+)
+
+const searchURL = "https://crt.name/v1/search?apex="
+
+// Source is the passive scraping agent
+type Source struct {
+	apiKeys   []string
+	timeTaken time.Duration
+	errors    int
+	results   int
+	requests  int
+}
+
+// Run function returns all subdomains found with the service
+func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
+	results := make(chan subscraping.Result)
+	s.errors = 0
+	s.results = 0
+	s.requests = 0
+
+	go func() {
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
+
+		s.requests++
+		resp, err := s.fetch(ctx, domain, session)
+		if err != nil {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
+			session.DiscardHTTPResponse(resp)
+			return
+		}
+
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+				s.errors++
+			}
+		}()
+
+		maxResults := session.MaxResults
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" || strings.HasPrefix(line, "*.") {
+				continue
+			}
+
+			for _, subdomain := range session.Extractor.Extract(line) {
+				select {
+				case <-ctx.Done():
+					return
+				case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}:
+					s.results++
+				}
+				if maxResults > 0 && s.results >= maxResults {
+					return
+				}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
+			s.errors++
+		}
+	}()
+
+	return results
+}
+
+func (s *Source) fetch(ctx context.Context, domain string, session *subscraping.Session) (*http.Response, error) {
+	endpoint := searchURL + url.QueryEscape(domain)
+	headers := map[string]string{"User-Agent": "subfinder"}
+	if len(s.apiKeys) > 0 {
+		headers["Authorization"] = "Bearer " + subscraping.PickRandom(s.apiKeys, s.Name())
+	}
+	return session.Get(ctx, endpoint, "", headers)
+}
+
+// Name returns the name of the source
+func (s *Source) Name() string {
+	return "crtname"
+}
+
+func (s *Source) IsDefault() bool {
+	return true
+}
+
+func (s *Source) HasRecursiveSupport() bool {
+	return false
+}
+
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.OptionalKey
+}
+
+func (s *Source) NeedsKey() bool {
+	return s.KeyRequirement() == subscraping.RequiredKey
+}
+
+func (s *Source) AddApiKeys(keys []string) {
+	s.apiKeys = keys
+}
+
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		Requests:  s.requests,
+		TimeTaken: s.timeTaken,
+	}
+}

--- a/pkg/subscraping/sources/crtname/crtname_test.go
+++ b/pkg/subscraping/sources/crtname/crtname_test.go
@@ -1,0 +1,193 @@
+package crtname
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/ratelimit"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type rewriteTransport struct {
+	target *url.URL
+}
+
+func (r *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = r.target.Scheme
+	req.URL.Host = r.target.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func newTestSession(t *testing.T, server *httptest.Server, domain string, maxResults int) *subscraping.Session {
+	t.Helper()
+	target, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	extractor, err := subscraping.NewSubdomainExtractor(domain)
+	require.NoError(t, err)
+
+	mrl, err := ratelimit.NewMultiLimiter(context.Background(), &ratelimit.Options{
+		Key:         "crtname",
+		IsUnlimited: false,
+		MaxCount:    math.MaxInt32,
+		Duration:    time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	return &subscraping.Session{
+		Client:           &http.Client{Transport: &rewriteTransport{target: target}, Timeout: 5 * time.Second},
+		MultiRateLimiter: mrl,
+		Extractor:        extractor,
+		MaxResults:       maxResults,
+	}
+}
+
+func runSource(t *testing.T, source *Source, session *subscraping.Session, domain string) (subs []string, errs []error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = context.WithValue(ctx, subscraping.CtxSourceArg, "crtname")
+
+	for r := range source.Run(ctx, domain, session) {
+		switch r.Type {
+		case subscraping.Subdomain:
+			subs = append(subs, r.Value)
+		case subscraping.Error:
+			errs = append(errs, r.Error)
+		}
+	}
+	return
+}
+
+func TestCrtnameSource_Metadata(t *testing.T) {
+	source := &Source{}
+	assert.Equal(t, "crtname", source.Name())
+	assert.True(t, source.IsDefault())
+	assert.False(t, source.HasRecursiveSupport())
+	assert.False(t, source.NeedsKey())
+	assert.Equal(t, subscraping.OptionalKey, source.KeyRequirement())
+}
+
+func TestCrtnameSource_ParsesPlaintext(t *testing.T) {
+	const domain = "hackerone.com"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/search", r.URL.Path)
+		assert.Equal(t, domain, r.URL.Query().Get("apex"))
+		assert.Equal(t, "subfinder", r.Header.Get("User-Agent"))
+		assert.Empty(t, r.Header.Get("Authorization"))
+		fmt.Fprint(w, "www.hackerone.com\napi.hackerone.com\n\n*.hackerone.com\nhackerone.com\n")
+	}))
+	t.Cleanup(server.Close)
+
+	source := &Source{}
+	subs, errs := runSource(t, source, newTestSession(t, server, domain, 0), domain)
+
+	assert.Empty(t, errs)
+	assert.ElementsMatch(t, []string{"www.hackerone.com", "api.hackerone.com"}, subs)
+	assert.Equal(t, 2, source.Statistics().Results)
+	assert.Equal(t, 1, source.Statistics().Requests)
+	assert.Equal(t, 0, source.Statistics().Errors)
+}
+
+func TestCrtnameSource_EmptyBody(t *testing.T) {
+	const domain = "hackerone.com"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	source := &Source{}
+	subs, errs := runSource(t, source, newTestSession(t, server, domain, 0), domain)
+
+	assert.Empty(t, errs)
+	assert.Empty(t, subs)
+}
+
+func TestCrtnameSource_NonOKStatus(t *testing.T) {
+	const domain = "www.example.com"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "invalid apex: not an apex (eTLD+1 is example.com)", http.StatusBadRequest)
+	}))
+	t.Cleanup(server.Close)
+
+	source := &Source{}
+	subs, errs := runSource(t, source, newTestSession(t, server, domain, 0), domain)
+
+	assert.Empty(t, subs)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), "400")
+	assert.Equal(t, 1, source.Statistics().Errors)
+}
+
+func TestCrtnameSource_MaxResults(t *testing.T) {
+	const domain = "hackerone.com"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "a.hackerone.com\nb.hackerone.com\nc.hackerone.com\nd.hackerone.com\n")
+	}))
+	t.Cleanup(server.Close)
+
+	source := &Source{}
+	subs, errs := runSource(t, source, newTestSession(t, server, domain, 2), domain)
+
+	assert.Empty(t, errs)
+	assert.Equal(t, []string{"a.hackerone.com", "b.hackerone.com"}, subs)
+	assert.Equal(t, 2, source.Statistics().Results)
+}
+
+func TestCrtnameSource_SendsBearerToken(t *testing.T) {
+	const domain = "hackerone.com"
+	var gotAuth atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth.Store(r.Header.Get("Authorization"))
+		fmt.Fprint(w, "www.hackerone.com\n")
+	}))
+	t.Cleanup(server.Close)
+
+	source := &Source{}
+	source.AddApiKeys([]string{"test-token"})
+	subs, errs := runSource(t, source, newTestSession(t, server, domain, 0), domain)
+
+	assert.Empty(t, errs)
+	assert.Equal(t, []string{"www.hackerone.com"}, subs)
+	assert.Equal(t, "Bearer test-token", gotAuth.Load())
+}
+
+func TestCrtnameSource_ContextCancel(t *testing.T) {
+	const domain = "hackerone.com"
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		time.Sleep(2 * time.Second)
+		fmt.Fprint(w, "www.hackerone.com\n")
+	}))
+	t.Cleanup(server.Close)
+
+	source := &Source{}
+	session := newTestSession(t, server, domain, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = context.WithValue(ctx, subscraping.CtxSourceArg, "crtname")
+
+	results := source.Run(ctx, domain, session)
+	<-started
+	cancel()
+
+	var got []subscraping.Result
+	for r := range results {
+		got = append(got, r)
+	}
+	for _, r := range got {
+		if r.Type == subscraping.Subdomain {
+			t.Fatalf("got subdomain after cancel: %s", r.Value)
+		}
+	}
+}


### PR DESCRIPTION
## Proposed changes

Adds [crt.name](https://crt.name/) as a `crtname` source. Closes #1831.

`GET /v1/search?apex=` returns one hostname per line. No token required. Free tier is 100 req/IP/day. A Bearer token is optional (`CRTNAME_API_KEY`, or `crtname:` in provider-config). `apex` must be an eTLD+1, so the source is not recursive.

On by default. `-ls` marks it `~`.

Wildcard lines (`*.example.com`) are skipped. The extractor drops the apex. User-Agent is `subfinder`.

### Proof

Unit tests in `pkg/subscraping/sources/crtname` cover plaintext parsing, empty lines, wildcards, empty 200, HTTP 400, `-max-results`, Bearer header, and context cancel.

`go test -short ./...` passes. `go test -race` on the new package and `pkg/passive` passes.

```
$ subfinder -d hackerone.com -s crtname -stats
Found 30 subdomains for hackerone.com in 280 milliseconds
crtname   280ms   30 results   1 request   0 errors
```

`www.example.com` returns HTTP 400. `-s crtname -recursive` selects no sources. An unknown apex returns 0 results and 0 errors.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/subfinder/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

---

**Disclosure:** I run crt.name. Happy to flip `IsDefault` off if 100 req/day on the free tier is too tight for a default source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added crt.name as a passive subdomain enumeration source.
  - The source is enabled by default and supports optional API-key authentication.
  - Results are filtered for valid subdomains and respect cancellation and result limits.
- **Documentation**
  - Added the crt.name Terms of Service URL to the leveraged services documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->