### PR TITLE
fix(github): correct processItems helper name

### DIFF
--- a/pkg/subscraping/sources/github/github.go
+++ b/pkg/subscraping/sources/github/github.go
@@ -123,7 +123,7 @@ func (s *Source) enumerate(ctx context.Context, searchURL string, domainRegexp *
 
 	session.DiscardHTTPResponse(resp)
 
-	err = s.proccesItems(ctx, data.Items, domainRegexp, s.Name(), session, results)
+	err = s.processItems(ctx, data.Items, domainRegexp, s.Name(), session, results)
 	if err != nil {
 		results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}
 		s.errors.Add(1)
@@ -151,8 +151,8 @@ func (s *Source) enumerate(ctx context.Context, searchURL string, domainRegexp *
 	}
 }
 
-// proccesItems process github response items
-func (s *Source) proccesItems(ctx context.Context, items []item, domainRegexp *regexp.Regexp, name string, session *subscraping.Session, results chan subscraping.Result) error {
+// processItems processes GitHub response items.
+func (s *Source) processItems(ctx context.Context, items []item, domainRegexp *regexp.Regexp, name string, session *subscraping.Session, results chan subscraping.Result) error {
 	var wg sync.WaitGroup
 	errChan := make(chan error, len(items))
 


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->


Fix the spelling of the GitHub source's unexported `processItems` helper, its comment, and its call site. This improves code navigation without changing behavior or public APIs.


### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->


    `go test ./pkg/subscraping/sources/github`

The package passes; it currently contains no package-local test files.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/subfinder/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Corrected an internal spelling error and updated its accompanying comment.
  * No user-visible functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->