### PR TITLE
test(subscraping): verify subdomain extraction boundary filters

### DIFF
--- a/pkg/runner/util_test.go
+++ b/pkg/runner/util_test.go
@@ -25,12 +25,15 @@ func TestPreprocessDomain(t *testing.T) {
 		{"trailing slash", "example.com/", "example.com"},
 		{"ip with scheme", "https://8.8.8.8", "8.8.8.8"},
 		{"resolver host port kept", "8.8.8.8:53", "8.8.8.8:53"},
+		{"https scheme with custom port", "https://example.com:8443/api", "example.com:8443"},
+		{"http scheme with custom port", "http://sub.example.com:8080?q=1", "sub.example.com:8080"},
 		{"wildcard kept", "*.example.com", "*.example.com"},
 		{"quoted and spaced", "  \"example.com\" ", "example.com"},
 		{"comment line", "# a comment", ""},
 		{"inline comment", "example.com # note", "example.com"},
 		{"empty", "", ""},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := preprocessDomain(tt.in); got != tt.want {

--- a/pkg/subscraping/extractor_test.go
+++ b/pkg/subscraping/extractor_test.go
@@ -73,6 +73,12 @@ func TestRegexSubdomainExtractor_Extract(t *testing.T) {
 			text:   "notexample.com",
 			want:   nil,
 		},
+		{
+			name:   "bracketed and json quoted subdomains",
+			domain: "example.com",
+			text:   `{"domain":"api.example.com","alt":["test.example.com"]}`,
+			want:   []string{"api.example.com", "test.example.com"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/subscraping/extractor_test.go
+++ b/pkg/subscraping/extractor_test.go
@@ -79,7 +79,14 @@ func TestRegexSubdomainExtractor_Extract(t *testing.T) {
 			text:   `{"domain":"api.example.com","alt":["test.example.com"]}`,
 			want:   []string{"api.example.com", "test.example.com"},
 		},
+		{
+			name:   "subdomains in full URL context",
+			domain: "example.com",
+			text:   `https://auth.example.com/login?redirect=https://admin.example.com:8080`,
+			want:   []string{"auth.example.com", "admin.example.com"},
+		},
 	}
+
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Summary of Changes
- Adds unit test coverage for subdomain extraction boundary filters and regex edge cases.
- `go test ./pkg/subscraping`: **passed 100% green**.