### PR TITLE
feat(abuseipdb): add passive source

### DIFF
--- a/pkg/passive/sources.go
+++ b/pkg/passive/sources.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/abuseipdb"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/alienvault"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/anubis"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping/sources/bevigil"
@@ -65,6 +66,7 @@ import (
 )
 
 var AllSources = [...]subscraping.Source{
+	&abuseipdb.Source{},
 	&alienvault.Source{},
 	&anubis.Source{},
 	&bevigil.Source{},

--- a/pkg/passive/sources_test.go
+++ b/pkg/passive/sources_test.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	expectedAllSources = []string{
+		"abuseipdb",
 		"alienvault",
 		"anubis",
 		"bevigil",
@@ -70,6 +71,7 @@ var (
 	}
 
 	expectedDefaultSources = []string{
+		"abuseipdb",
 		"alienvault",
 		"anubis",
 		"bevigil",

--- a/pkg/passive/sources_wo_auth_test.go
+++ b/pkg/passive/sources_wo_auth_test.go
@@ -24,6 +24,7 @@ func TestSourcesWithoutKeys(t *testing.T) {
 	}
 
 	ignoredSources := []string{
+		"abuseipdb",      // Cloudflare managed challenge (403) once an IP has made repeated requests
 		"commoncrawl",    // commoncrawl is under resourced and will likely time-out so step over it for this test https://groups.google.com/u/2/g/common-crawl/c/3QmQjFA_3y4/m/vTbhGqIBBQAJ
 		"riddler",        // failing due to cloudfront protection
 		"crtsh",          // Fails in GH Action (possibly IP-based ban) causing a timeout.

--- a/pkg/subscraping/sources/abuseipdb/abuseipdb.go
+++ b/pkg/subscraping/sources/abuseipdb/abuseipdb.go
@@ -1,0 +1,148 @@
+// Package abuseipdb logic
+package abuseipdb
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+	"github.com/projectdiscovery/utils/dns/wildcard"
+)
+
+// The whois page answers 403 without a session cookie; an empty value passes.
+const sessionCookie = "abuseipdb_session="
+
+// EPP status codes such as clientTransferProhibited use the same bare <li>
+// markup, so match only after this heading to keep them out of the results.
+const subdomainsHeading = "<h4>Subdomains</h4>"
+
+var reSubdomain = regexp.MustCompile(`<li>([^<]+)</li>`)
+
+// Source is the passive scraping agent
+type Source struct {
+	timeTaken time.Duration
+	errors    int
+	results   int
+	requests  int
+}
+
+// Run function returns all subdomains found with the service
+func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
+	results := make(chan subscraping.Result)
+	s.errors = 0
+	s.results = 0
+	s.requests = 0
+
+	go func() {
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
+
+		// Whois answers for the registrable domain whatever host it is given,
+		// so the labels it returns belong to that root rather than to domain.
+		// Appending them to domain instead would invent names such as
+		// www.app.example.com. The runner drops whatever falls out of scope.
+		root, ok := wildcard.RegistrableRoot(domain)
+		if !ok {
+			return
+		}
+
+		s.requests++
+		resp, err := session.Get(ctx, fmt.Sprintf("https://www.abuseipdb.com/whois/%s", root), sessionCookie, nil)
+		if err != nil {
+			s.sendError(ctx, results, err)
+			session.DiscardHTTPResponse(resp)
+			return
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			session.DiscardHTTPResponse(resp)
+			return
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			s.sendError(ctx, results, err)
+			// DiscardHTTPResponse gives up without closing when the drain
+			// fails, which it will after a read error, so close it here.
+			_ = resp.Body.Close()
+			return
+		}
+
+		session.DiscardHTTPResponse(resp)
+
+		_, subdomainsSection, found := strings.Cut(string(body), subdomainsHeading)
+		if !found {
+			return
+		}
+
+		for _, match := range reSubdomain.FindAllStringSubmatch(subdomainsSection, -1) {
+			label := strings.TrimSpace(match[1])
+			if label == "" {
+				continue
+			}
+			subdomain := fmt.Sprintf("%s.%s", label, root)
+
+			select {
+			case <-ctx.Done():
+				return
+			case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}:
+				s.results++
+			}
+		}
+	}()
+
+	return results
+}
+
+// sendError matches the subdomain path: results is unbuffered, so a consumer
+// that stopped reading after cancellation would otherwise block the send.
+func (s *Source) sendError(ctx context.Context, results chan<- subscraping.Result, err error) {
+	select {
+	case <-ctx.Done():
+	case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}:
+		s.errors++
+	}
+}
+
+// Name returns the name of the source
+func (s *Source) Name() string {
+	return "abuseipdb"
+}
+
+func (s *Source) IsDefault() bool {
+	return true
+}
+
+// Off because every query resolves to the registrable domain, so feeding a
+// discovered subdomain back in returns the same list a second time.
+func (s *Source) HasRecursiveSupport() bool {
+	return false
+}
+
+func (s *Source) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}
+
+func (s *Source) NeedsKey() bool {
+	return s.KeyRequirement() == subscraping.RequiredKey
+}
+
+func (s *Source) AddApiKeys(_ []string) {
+	// no key needed
+}
+
+func (s *Source) Statistics() subscraping.Statistics {
+	return subscraping.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		Requests:  s.requests,
+		TimeTaken: s.timeTaken,
+	}
+}

--- a/pkg/subscraping/sources/abuseipdb/abuseipdb.go
+++ b/pkg/subscraping/sources/abuseipdb/abuseipdb.go
@@ -53,6 +53,11 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 			return
 		}
 
+		// Honor an optional per-source result limit (0 = no limit). One request
+		// serves the whole page, so this caps what is emitted rather than
+		// saving a fetch the way it does for the paginating sources.
+		maxResults := session.MaxResults
+
 		s.requests++
 		resp, err := session.Get(ctx, fmt.Sprintf("https://www.abuseipdb.com/whois/%s", root), sessionCookie, nil)
 		if err != nil {
@@ -94,6 +99,10 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 				return
 			case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Subdomain, Value: subdomain}:
 				s.results++
+			}
+
+			if maxResults > 0 && s.results >= maxResults {
+				return
 			}
 		}
 	}()

--- a/pkg/subscraping/sources/abuseipdb/abuseipdb.go
+++ b/pkg/subscraping/sources/abuseipdb/abuseipdb.go
@@ -104,10 +104,12 @@ func (s *Source) Run(ctx context.Context, domain string, session *subscraping.Se
 // sendError matches the subdomain path: results is unbuffered, so a consumer
 // that stopped reading after cancellation would otherwise block the send.
 func (s *Source) sendError(ctx context.Context, results chan<- subscraping.Result, err error) {
+	// Count the error even when cancellation wins the select, so Statistics
+	// reports what went wrong rather than only what was delivered.
+	s.errors++
 	select {
 	case <-ctx.Done():
 	case results <- subscraping.Result{Source: s.Name(), Type: subscraping.Error, Error: err}:
-		s.errors++
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

Adds `abuseipdb` as a keyless passive source. It reads `https://www.abuseipdb.com/whois/{domain}` and returns the subdomain list the page renders. No API key, registered in the default set.

Two details drive the implementation:

**Session cookie.** The page answers `403` to a request carrying no session cookie. An empty `abuseipdb_session=` value satisfies it, so the source uses `session.Get` rather than `session.SimpleGet`.

**EPP status codes.** The page renders the domain's EPP status codes in the same bare `<li>` markup it uses for subdomains, so a plain `<li>([^<]+)</li>` match reports `clientTransferProhibited` as a subdomain. Those codes sit in their own `<ul>` above the `<h4>Subdomains</h4>` heading, so the match is anchored after that heading instead of filtering by keyword.

`HasRecursiveSupport` is false: the service resolves a query to the registrable domain, so `/whois/app.example.com` returns `example.com`'s names, which this source would otherwise emit as `www.app.example.com`.

### Proof

`-s abuseipdb`, keyless:

| domain | subdomains | time |
|---|---|---|
| ycombinator.com | 71 | ~1.1s |
| kernel.org | 165 | 1.084s |

Confirmed on `ycombinator.com` that the heading anchor drops exactly `clientTransferProhibited` and no real name.

`go build ./...`, `go vet ./...` and `go test ./...` pass.

The host is behind Cloudflare and issues a managed challenge (`cf-mitigated: challenge`) to an IP that has made repeated requests, so the source is added to `ignoredSources` in `TestSourcesWithoutKeys` alongside the existing `dnsdumpster` and `crtsh` entries.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/subfinder/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AbuseIPDB as a default passive source for subdomain enumeration.
  * Scan results now include subdomains discovered from AbuseIPDB domain information pages.
  * AbuseIPDB lookups work without an API key.
  * Results honor configured limits, while scans provide standard statistics and support cancellation.
* **Bug Fixes**
  * Unavailable or unsuccessful AbuseIPDB responses are handled without interrupting the overall scan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->