### PR TITLE
fix: normalize source-reported subdomains before domain check

### DIFF
--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -66,10 +66,11 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 			case subscraping.Error:
 				gologger.Warning().Msgf("Encountered an error with source %s: %s\n", result.Source, result.Error)
 			case subscraping.Subdomain:
-				subdomain := replacer.Replace(result.Value)
+				value := normalizeSubdomain(result.Value)
+				subdomain := replacer.Replace(value)
 				// check if this subdomain is actually a wildcard subdomain
 				// that may have furthur subdomains associated with it
-				isWildcard := strings.Contains(result.Value, "*."+subdomain)
+				isWildcard := strings.Contains(value, "*."+subdomain)
 
 				// Validate the subdomain found and remove wildcards from
 				if !strings.HasSuffix(subdomain, "."+domain) {

--- a/pkg/runner/util.go
+++ b/pkg/runner/util.go
@@ -40,3 +40,10 @@ func preprocessDomain(s string) string {
 	}
 	return s
 }
+
+// normalizeSubdomain normalizes a subdomain reported by a source. Sources
+// reporting hosts verbatim keep the FQDN trailing dot or mixed case, which
+// the domain suffix check in the enumerator would otherwise reject.
+func normalizeSubdomain(s string) string {
+	return strings.TrimSuffix(strings.ToLower(s), ".")
+}

--- a/pkg/runner/util_test.go
+++ b/pkg/runner/util_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -37,6 +38,55 @@ func TestPreprocessDomain(t *testing.T) {
 				t.Fatalf("preprocessDomain(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNormalizeSubdomain(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare subdomain", "www.example.com", "www.example.com"},
+		{"trailing dot", "www.example.com.", "www.example.com"},
+		{"uppercase", "WWW.Example.COM", "www.example.com"},
+		{"uppercase and trailing dot", "WWW.EXAMPLE.COM.", "www.example.com"},
+		{"wildcard kept", "*.sub.example.com", "*.sub.example.com"},
+		{"wildcard and trailing dot", "*.sub.example.com.", "*.sub.example.com"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeSubdomain(tt.in); got != tt.want {
+				t.Fatalf("normalizeSubdomain(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubdomainPassesDomainGate(t *testing.T) {
+	domain := "example.com"
+	// Values as reported verbatim by sources that do not normalize their
+	// output: trailing-dot FQDNs from DNS-centric APIs, mixed-case hosts
+	// from certificate data and code search matches.
+	for _, value := range []string{
+		"www.example.com",
+		"www.example.com.",
+		"WWW.Example.com",
+		"dev.EXAMPLE.com",
+		"*.sub.example.com.",
+		"https://www.EXAMPLE.com",
+	} {
+		subdomain := replacer.Replace(normalizeSubdomain(value))
+		if !strings.HasSuffix(subdomain, "."+domain) {
+			t.Fatalf("expected %q to pass the domain gate, got %q", value, subdomain)
+		}
+	}
+	for _, value := range []string{"example.com", "notexample.com", "foo.example.com.evil.org"} {
+		subdomain := replacer.Replace(normalizeSubdomain(value))
+		if strings.HasSuffix(subdomain, "."+domain) {
+			t.Fatalf("expected %q to be rejected by the domain gate, got %q", value, subdomain)
+		}
 	}
 }
 


### PR DESCRIPTION
Sources that report hosts verbatim — certificate names from certspotter/censys, code-search matches from github, FQDNs from DNS-style APIs — can return values with a trailing dot or mixed case. The suffix check in the enumerator is case- and dot-sensitive, so these results are silently dropped (dnsdb and dnsrepo already trim the dot at the source to work around this).

This normalizes the value once, centrally, before the check, mirroring what `preprocessDomain` does for input domains and what the regex extractor already does for text sources. Values that already pass are unaffected, and apexes, label fusions (`notexample.com`) and other-apex hosts (`foo.example.com.evil.org`) are still rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subdomain handling by normalizing capitalization and trailing dots before wildcard and domain matching.
  * Ensured valid fully qualified domain names are recognized consistently, while non-matching and spoofed domain values remain rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->