### PR TITLE
feat: add bounded concurrent domain enumeration

### DIFF
--- a/pkg/passive/custom_sources_test.go
+++ b/pkg/passive/custom_sources_test.go
@@ -1,0 +1,271 @@
+package passive
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+)
+
+type registeredSource struct {
+	name    string
+	keys    []string
+	started chan string
+	release chan struct{}
+	active  atomic.Int32
+	maximum atomic.Int32
+	stats   subscraping.Statistics
+}
+
+func (s *registeredSource) Name() string              { return s.name }
+func (s *registeredSource) IsDefault() bool           { return true }
+func (s *registeredSource) HasRecursiveSupport() bool { return true }
+func (s *registeredSource) NeedsKey() bool            { return true }
+func (s *registeredSource) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.RequiredKey
+}
+func (s *registeredSource) AddApiKeys(keys []string)           { s.keys = keys }
+func (s *registeredSource) Statistics() subscraping.Statistics { return s.stats }
+func (s *registeredSource) Run(_ context.Context, domain string, _ *subscraping.Session) <-chan subscraping.Result {
+	results := make(chan subscraping.Result)
+	active := s.active.Add(1)
+	if active > s.maximum.Load() {
+		s.maximum.Store(active)
+	}
+	s.started <- domain
+	go func() {
+		defer close(results)
+		defer s.active.Add(-1)
+		<-s.release
+		s.stats = subscraping.Statistics{Results: len(domain)}
+		results <- subscraping.Result{Value: domain + ":" + s.keys[0]}
+	}()
+	return results
+}
+
+func registerTestSource(t *testing.T, name string) *registeredSource {
+	t.Helper()
+	old, existed := NameSourceMap[name]
+	t.Cleanup(func() {
+		if existed {
+			NameSourceMap[name] = old
+		} else {
+			delete(NameSourceMap, name)
+		}
+	})
+	source := &registeredSource{name: name, keys: []string{"preconfigured"}, started: make(chan string, 2), release: make(chan struct{}, 2)}
+	NameSourceMap[name] = source
+	return source
+}
+
+func TestCustomSourceSelectionAndSerialization(t *testing.T) {
+	for _, name := range []string{"shodan", "test-custom-source"} {
+		t.Run(name, func(t *testing.T) {
+			source := registerTestSource(t, name)
+			first := NewWithProviderConfig([]string{name}, nil, false, false, nil)
+			second := NewWithProviderConfig([]string{name}, nil, false, false, map[string][]string{name: {"second-key"}})
+			if _, ok := first.sources[0].(*registeredSource); ok {
+				t.Fatal("custom source was not isolated")
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			one := first.sources[0].Run(ctx, "one", nil)
+			select {
+			case <-source.started:
+			case <-ctx.Done():
+				t.Fatal("custom source override was not used")
+			}
+			two := second.sources[0].Run(ctx, "second", nil)
+			source.release <- struct{}{}
+			var values []string
+			for result := range one {
+				values = append(values, result.Value)
+			}
+			select {
+			case <-source.started:
+			case <-ctx.Done():
+				t.Fatal("second source did not start")
+			}
+			source.release <- struct{}{}
+			for result := range two {
+				values = append(values, result.Value)
+			}
+			if len(values) != 2 || values[0] != "one:preconfigured" || values[1] != "second:second-key" {
+				t.Fatalf("results: %v", values)
+			}
+			if source.maximum.Load() != 1 {
+				t.Fatal("custom source ran concurrently")
+			}
+			if first.GetStatistics()[name].Results != 3 || second.GetStatistics()[name].Results != 6 {
+				t.Fatal("statistics not isolated")
+			}
+		})
+	}
+}
+
+func TestCustomSourceCancellationWhileWaiting(t *testing.T) {
+	source := registerTestSource(t, "test-custom-cancel")
+	first := NewWithProviderConfig([]string{source.name}, nil, false, false, nil)
+	second := NewWithProviderConfig([]string{source.name}, nil, false, false, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	one := first.sources[0].Run(ctx, "one", nil)
+	select {
+	case <-source.started:
+	case <-ctx.Done():
+		t.Fatal("first source did not start")
+	}
+	waitCtx, waitCancel := context.WithCancel(ctx)
+	two := second.sources[0].Run(waitCtx, "two", nil)
+	waitCancel()
+	select {
+	case _, ok := <-two:
+		if ok {
+			t.Fatal("canceled waiter emitted a result")
+		}
+	case <-ctx.Done():
+		t.Fatal("canceled waiter blocked")
+	}
+	source.release <- struct{}{}
+	for range one {
+	}
+	select {
+	case <-source.started:
+		t.Fatal("canceled source ran")
+	default:
+	}
+}
+
+func TestCustomSourceDrainsAfterCancellation(t *testing.T) {
+	source := registerTestSource(t, "test-custom-drain")
+	agent := NewWithProviderConfig([]string{source.name}, nil, false, false, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	results := agent.sources[0].Run(ctx, "one", nil)
+	select {
+	case <-source.started:
+	case <-time.After(time.Second):
+		t.Fatal("source did not start")
+	}
+	cancel()
+	source.release <- struct{}{}
+	done := make(chan struct{})
+	go func() {
+		for range results {
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("canceled enumeration did not drain custom source")
+	}
+	if source.active.Load() != 0 || agent.GetStatistics()[source.name].Results != 3 {
+		t.Fatal("custom source did not finish and preserve statistics")
+	}
+}
+
+// A custom adapter may use the legacy public Session limiter directly.
+type legacyLimiterSource struct{ blockingSource }
+
+func (s *legacyLimiterSource) Run(_ context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
+	results := make(chan subscraping.Result, 1)
+	defer close(results)
+	if session.MultiRateLimiter == nil {
+		results <- subscraping.Result{Type: subscraping.Error}
+		return results
+	}
+	if err := session.MultiRateLimiter.Take(s.Name()); err != nil {
+		results <- subscraping.Result{Type: subscraping.Error, Error: err}
+		return results
+	}
+	results <- subscraping.Result{Source: s.Name(), Value: "www." + domain}
+	return results
+}
+func TestCustomSourceLegacySessionLimiter(t *testing.T) {
+	source := &legacyLimiterSource{}
+	previous, exists := NameSourceMap[source.Name()]
+	NameSourceMap[source.Name()] = source
+	t.Cleanup(func() {
+		if exists {
+			NameSourceMap[source.Name()] = previous
+		} else {
+			delete(NameSourceMap, source.Name())
+		}
+	})
+	agent := NewWithProviderConfig([]string{source.Name()}, nil, false, false, nil)
+	count := 0
+	for result := range agent.EnumerateSubdomains("example.com", "", 0, 1, time.Second, WithRateLimiter(testRateLimiter(t, agent, 0, nil))) {
+		if result.Type == subscraping.Error {
+			t.Fatal("custom adapter lost its legacy session limiter")
+		}
+		count++
+	}
+	if count != 1 {
+		t.Fatalf("results=%d, want 1", count)
+	}
+}
+
+func TestCustomSourceLegacySharedBudget(t *testing.T) {
+	source := &legacyLimiterSource{}
+	previous, exists := NameSourceMap[source.Name()]
+	NameSourceMap[source.Name()] = source
+	t.Cleanup(func() {
+		if exists {
+			NameSourceMap[source.Name()] = previous
+		} else {
+			delete(NameSourceMap, source.Name())
+		}
+	})
+	custom := newCustomRateLimit(map[string]uint{source.Name(): 1}, map[string]time.Duration{source.Name(): 40 * time.Millisecond})
+	agents := make([]*Agent, 4)
+	for i := range agents {
+		agents[i] = NewWithProviderConfig([]string{source.Name()}, nil, false, false, nil)
+	}
+	limiter := testRateLimiter(t, agents[0], 0, custom)
+	started := time.Now()
+	done := make(chan struct{}, 4)
+	for _, agent := range agents {
+		go func() {
+			for range agent.EnumerateSubdomains("example.com", "", 0, 1, time.Second, WithCustomRateLimit(custom), WithRateLimiter(limiter)) {
+			}
+			done <- struct{}{}
+		}()
+	}
+	for range agents {
+		<-done
+	}
+	if elapsed := time.Since(started); elapsed < 80*time.Millisecond {
+		t.Fatalf("custom source received fresh per-domain bursts: %s", elapsed)
+	}
+}
+
+func TestCustomSourceUnconfiguredRetainsSharedConfiguration(t *testing.T) {
+	source := registerTestSource(t, "test-shared-config")
+	inherited := NewWithProviderConfig([]string{source.Name()}, nil, false, false, nil)
+	configured := NewWithProviderConfig([]string{source.Name()}, nil, false, false, map[string][]string{source.Name(): {"configured"}})
+	// The legacy registry exposes one mutable instance and no key getter. An
+	// unconfigured custom source inherits its current configuration, not a snapshot.
+	for _, agent := range []*Agent{configured, inherited} {
+		source.release <- struct{}{}
+		for result := range agent.sources[0].Run(context.Background(), "domain", nil) {
+			if result.Value != "domain:configured" {
+				t.Fatalf("custom registry configuration changed: %q", result.Value)
+			}
+		}
+	}
+}
+
+func TestCustomSourceLegacyLimiterScope(t *testing.T) {
+	source := registerTestSource(t, "test-legacy-scope")
+	agent := NewWithProviderConfig([]string{source.Name(), "anubis"}, nil, false, false, nil)
+	limiter := testRateLimiter(t, agent, 1, nil)
+	if _, err := limiter.legacy.GetLimit(source.Name()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := limiter.legacy.GetLimit("anubis"); err == nil {
+		t.Fatal("built-in source has an unused legacy limiter")
+	}
+}

--- a/pkg/passive/limiter.go
+++ b/pkg/passive/limiter.go
@@ -1,0 +1,148 @@
+package passive
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/projectdiscovery/ratelimit"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+)
+
+// RateLimiter shares provider budgets across a domain batch. Built-in requests
+// use cancellable fixed windows. Custom adapters retain one shared legacy limiter
+// because they may access Session.MultiRateLimiter directly.
+// Call Close after all enumerations finish.
+type RateLimiter struct {
+	sources       map[string]*sourceBudget
+	legacy        *ratelimit.MultiLimiter
+	legacySources map[string]bool
+	stop          func() bool
+}
+
+type sourceBudget struct {
+	mu               sync.Mutex
+	limit, remaining uint
+	period           time.Duration
+	start            time.Time
+}
+
+// NewRateLimiter creates provider budgets shared by a domain batch.
+// Per-source settings override the global default, as for single-domain runs.
+func (a *Agent) NewRateLimiter(ctx context.Context, globalRateLimit int, custom *subscraping.CustomRateLimit) (*RateLimiter, error) {
+	if custom == nil {
+		custom = &subscraping.CustomRateLimit{}
+	}
+
+	limiter := &RateLimiter{sources: make(map[string]*sourceBudget, len(a.sources)), legacySources: make(map[string]bool)}
+	now := time.Now()
+
+	for _, source := range a.sources {
+		limit, period := resolveSourceRateLimit(globalRateLimit, custom, source.Name())
+		if _, legacy := source.(*serializedSource); legacy {
+			legacyLimit, legacyPeriod := limit, period
+			if legacyLimit == 0 {
+				legacyLimit, legacyPeriod = math.MaxUint32, time.Millisecond
+			}
+
+			var err error
+
+			limiter.legacy, err = addRateLimiter(ctx, limiter.legacy, source.Name(), legacyLimit, legacyPeriod)
+			if err != nil {
+				_ = limiter.Close()
+
+				return nil, err
+			}
+
+			limiter.legacySources[source.Name()] = true
+		}
+
+		var budget *sourceBudget
+
+		if limit > 0 {
+			budget = &sourceBudget{limit: limit, remaining: limit, period: period, start: now}
+		}
+
+		limiter.sources[source.Name()] = budget
+	}
+
+	if limiter.legacy != nil {
+		limiter.stop = context.AfterFunc(ctx, func() { limiter.legacy.Stop() })
+	}
+
+	return limiter, nil
+}
+
+// Close releases the legacy custom-source limiter, if any.
+func (l *RateLimiter) Close() error {
+	if l.stop != nil {
+		l.stop()
+	}
+
+	if l.legacy != nil {
+		l.legacy.Stop()
+	}
+
+	return nil
+}
+
+// Wait waits for a source budget. Legacy custom adapters keep their original
+// blocking Take behavior; their runs are serialized by the custom-source gate.
+func (l *RateLimiter) Wait(ctx context.Context, source string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if l.legacySources[source] {
+		if err := l.legacy.Take(source); err != nil {
+			return err
+		}
+		return ctx.Err()
+	}
+
+	budget, ok := l.sources[source]
+	if !ok {
+		return fmt.Errorf("no rate limit configured for source %s", source)
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		if budget == nil {
+			return nil
+		}
+
+		budget.mu.Lock()
+		now := time.Now()
+		elapsed := now.Sub(budget.start)
+
+		if elapsed >= budget.period {
+			// Keep window boundaries anchored to batch creation even after idle time.
+			budget.start = now.Add(-(elapsed % budget.period))
+			budget.remaining = budget.limit
+			elapsed = now.Sub(budget.start)
+		}
+
+		if budget.remaining > 0 {
+			budget.remaining--
+			budget.mu.Unlock()
+
+			return nil
+		}
+
+		delay := budget.period - elapsed
+		budget.mu.Unlock()
+		timer := time.NewTimer(delay)
+
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}

--- a/pkg/passive/limiter_test.go
+++ b/pkg/passive/limiter_test.go
@@ -1,0 +1,152 @@
+package passive
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+)
+
+type limiterTransport struct{}
+
+func (limiterTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("ok")), Header: make(http.Header), Request: req}, nil
+}
+
+func TestSharedRateLimiterCanceledRequests(t *testing.T) {
+	agent := &Agent{sources: []subscraping.Source{&blockingSource{}}}
+	crl := newCustomRateLimit(map[string]uint{"mock": 1}, map[string]time.Duration{"mock": 200 * time.Millisecond})
+	limiter := testRateLimiter(t, agent, 0, crl)
+	if err := limiter.Wait(context.Background(), "mock"); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.WithValue(context.Background(), subscraping.CtxSourceArg, "mock"), 20*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			session := &subscraping.Session{RequestLimiter: limiter, Client: &http.Client{Transport: limiterTransport{}}}
+			response, err := session.SimpleGet(ctx, "https://mock.invalid")
+			if response != nil {
+				session.DiscardHTTPResponse(response)
+			}
+			if err == nil {
+				t.Error("canceled request succeeded")
+			}
+		}()
+	}
+	wg.Wait()
+	if elapsed := time.Since(start); elapsed > 150*time.Millisecond {
+		t.Fatalf("expired requests waited for provider refills: %s", elapsed)
+	}
+}
+
+func TestSharedRateLimiterBurstAndCancellation(t *testing.T) {
+	agent := &Agent{sources: []subscraping.Source{&blockingSource{}}}
+	limiter := testRateLimiter(t, agent, 100, newCustomRateLimit(map[string]uint{"mock": 2}, map[string]time.Duration{"mock": 100 * time.Millisecond}))
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	var wg sync.WaitGroup
+	successful := make(chan struct{}, 20)
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if limiter.Wait(ctx, "mock") == nil {
+				successful <- struct{}{}
+			}
+		}()
+	}
+	wg.Wait()
+	if len(successful) != 2 {
+		t.Fatalf("initial burst=%d, want 2", len(successful))
+	}
+	// Expired waiters must not reserve tokens in the next window.
+	next, cancelNext := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancelNext()
+	for range 2 {
+		if err := limiter.Wait(next, "mock"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	canceled, stop := context.WithCancel(context.Background())
+	stop()
+	if err := limiter.Wait(canceled, "mock"); err != context.Canceled {
+		t.Fatalf("canceled wait=%v", err)
+	}
+	if err := limiter.Wait(context.Background(), "missing"); err == nil {
+		t.Fatal("missing source accepted")
+	}
+}
+
+func TestSharedRateLimiterUnlimited(t *testing.T) {
+	agent := &Agent{sources: []subscraping.Source{&blockingSource{}}}
+	limiter := testRateLimiter(t, agent, 0, nil)
+	for range 100 {
+		if err := limiter.Wait(context.Background(), "mock"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := limiter.Wait(ctx, "mock"); err != context.Canceled {
+		t.Fatalf("unlimited canceled wait=%v", err)
+	}
+}
+
+type requestingSource struct{ blockingSource }
+
+func (s *requestingSource) Run(ctx context.Context, _ string, session *subscraping.Session) <-chan subscraping.Result {
+	results := make(chan subscraping.Result)
+	session.Client.Transport = limiterTransport{}
+	go func() {
+		defer close(results)
+		response, err := session.SimpleGet(ctx, "https://mock.invalid")
+		if response != nil {
+			session.DiscardHTTPResponse(response)
+		}
+		if err != nil {
+			results <- subscraping.Result{Type: subscraping.Error, Error: err}
+		}
+	}()
+	return results
+}
+func TestSharedRateLimiterEnumerationDeadline(t *testing.T) {
+	agent := &Agent{sources: []subscraping.Source{&requestingSource{}}}
+	limiter := testRateLimiter(t, agent, 0, newCustomRateLimit(map[string]uint{"mock": 1}, map[string]time.Duration{"mock": time.Second}))
+	if err := limiter.Wait(context.Background(), "mock"); err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range agent.EnumerateSubdomains("example.com", "", 0, 1, 20*time.Millisecond, WithRateLimiter(limiter)) {
+			}
+		}()
+	}
+	wg.Wait()
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("domain deadlines waited for refill: %s", elapsed)
+	}
+}
+
+func testRateLimiter(t *testing.T, agent *Agent, global int, custom *subscraping.CustomRateLimit) *RateLimiter {
+	t.Helper()
+	limiter, err := agent.NewRateLimiter(context.Background(), global, custom)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = limiter.Close() })
+	return limiter
+}

--- a/pkg/passive/passive.go
+++ b/pkg/passive/passive.go
@@ -15,12 +15,21 @@ import (
 )
 
 type EnumerationOptions struct {
+	rateLimiter         subscraping.RequestLimiter
 	customRateLimiter   *subscraping.CustomRateLimit
 	maxResults          int
 	maxResponseBodySize int64
 }
 
 type EnumerateOption func(opts *EnumerationOptions)
+
+// WithRateLimiter borrows a request budget shared across enumerations.
+// It overrides per-enumeration limits; sessions do not own its lifetime.
+func WithRateLimiter(limiter subscraping.RequestLimiter) EnumerateOption {
+	return func(opts *EnumerationOptions) {
+		opts.rateLimiter = limiter
+	}
+}
 
 func WithCustomRateLimit(crl *subscraping.CustomRateLimit) EnumerateOption {
 	return func(opts *EnumerationOptions) {
@@ -62,7 +71,15 @@ func (a *Agent) EnumerateSubdomainsWithCtx(ctx context.Context, domain string, p
 			enumerateOption(&enumerateOptions)
 		}
 
-		multiRateLimiter, err := a.buildMultiRateLimiter(ctx, rateLimit, enumerateOptions.customRateLimiter)
+		var multiRateLimiter *ratelimit.MultiLimiter
+		var err error
+		borrowedLegacy := false
+		if limiter, ok := enumerateOptions.rateLimiter.(*RateLimiter); ok && limiter.legacy != nil {
+			multiRateLimiter = limiter.legacy
+			borrowedLegacy = true
+		} else if enumerateOptions.rateLimiter == nil {
+			multiRateLimiter, err = a.buildMultiRateLimiter(ctx, rateLimit, enumerateOptions.customRateLimiter)
+		}
 		if err != nil {
 			results <- subscraping.Result{
 				Type: subscraping.Error, Error: fmt.Errorf("could not init multi rate limiter for %s: %s", domain, err),
@@ -71,12 +88,20 @@ func (a *Agent) EnumerateSubdomainsWithCtx(ctx context.Context, domain string, p
 		}
 		session, err := subscraping.NewSession(domain, proxy, multiRateLimiter, timeout)
 		if err != nil {
+			if !borrowedLegacy && multiRateLimiter != nil {
+				multiRateLimiter.Stop()
+			}
 			results <- subscraping.Result{
 				Type: subscraping.Error, Error: fmt.Errorf("could not init passive session for %s: %s", domain, err),
 			}
 			return
 		}
-		defer session.Close()
+		session.RequestLimiter = enumerateOptions.rateLimiter
+		if borrowedLegacy {
+			defer session.Client.CloseIdleConnections()
+		} else {
+			defer session.Close()
+		}
 		session.MaxResults = enumerateOptions.maxResults
 		session.MaxResponseBodySize = enumerateOptions.maxResponseBodySize
 
@@ -132,7 +157,10 @@ func (a *Agent) buildMultiRateLimiter(ctx context.Context, globalRateLimit int, 
 		}
 
 		if err != nil {
-			break
+			if multiRateLimiter != nil {
+				multiRateLimiter.Stop()
+			}
+			return nil, err
 		}
 	}
 	return multiRateLimiter, err

--- a/pkg/passive/sources.go
+++ b/pkg/passive/sources.go
@@ -1,11 +1,13 @@
 package passive
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"os"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
@@ -64,62 +66,66 @@ import (
 	mapsutil "github.com/projectdiscovery/utils/maps"
 )
 
-var AllSources = [...]subscraping.Source{
-	&alienvault.Source{},
-	&anubis.Source{},
-	&bevigil.Source{},
-	&bufferover.Source{},
-	&builtwith.Source{},
-	&c99.Source{},
-	&censys.Source{},
-	&certspotter.Source{},
-	&chaos.Source{},
-	&chinaz.Source{},
-	&commoncrawl.Source{},
-	&crtsh.Source{},
-	&digitalyama.Source{},
-	&digitorus.Source{},
-	&dnsdb.Source{},
-	&dnsdumpster.Source{},
-	&dnsrepo.Source{},
-	&domainsproject.Source{},
-	&driftnet.Source{},
-	&fofa.Source{},
-	&fullhunt.Source{},
-	&github.Source{},
-	&hackertarget.Source{},
-	&hudsonrock.Source{},
-	&intelx.Source{},
-	&leakix.Source{},
-	&merklemap.Source{},
-	&netlas.Source{},
-	&onyphe.Source{},
-	&profundis.Source{},
-	&pugrecon.Source{},
-	&quake.Source{},
-	&rapiddns.Source{},
-	// &reconcloud.Source{}, // failing due to cloudflare bot protection
-	&reconeer.Source{},
-	&redhuntlabs.Source{},
-	// &riddler.Source{}, // failing due to cloudfront protection
-	&robtex.Source{},
-	&rsecloud.Source{},
-	&scanmalware.Source{},
-	&securitytrails.Source{},
-	&shodan.Source{},
-	&shodanct.Source{},
-	&sitedossier.Source{},
-	&thc.Source{},
-	&threatbook.Source{},
-	&threatcrowd.Source{},
-	// &threatminer.Source{}, // failing  api
-	&urlscan.Source{},
-	&virustotal.Source{},
-	&waybackarchive.Source{},
-	&whoisxmlapi.Source{},
-	&windvane.Source{},
-	&zoomeyeapi.Source{},
-	&submd.Source{},
+var AllSources = newSources()
+
+func newSources() [52]subscraping.Source {
+	return [...]subscraping.Source{
+		&alienvault.Source{},
+		&anubis.Source{},
+		&bevigil.Source{},
+		&bufferover.Source{},
+		&builtwith.Source{},
+		&c99.Source{},
+		&censys.Source{},
+		&certspotter.Source{},
+		&chaos.Source{},
+		&chinaz.Source{},
+		&commoncrawl.Source{},
+		&crtsh.Source{},
+		&digitalyama.Source{},
+		&digitorus.Source{},
+		&dnsdb.Source{},
+		&dnsdumpster.Source{},
+		&dnsrepo.Source{},
+		&domainsproject.Source{},
+		&driftnet.Source{},
+		&fofa.Source{},
+		&fullhunt.Source{},
+		&github.Source{},
+		&hackertarget.Source{},
+		&hudsonrock.Source{},
+		&intelx.Source{},
+		&leakix.Source{},
+		&merklemap.Source{},
+		&netlas.Source{},
+		&onyphe.Source{},
+		&profundis.Source{},
+		&pugrecon.Source{},
+		&quake.Source{},
+		&rapiddns.Source{},
+		// &reconcloud.Source{}, // failing due to cloudflare bot protection
+		&reconeer.Source{},
+		&redhuntlabs.Source{},
+		// &riddler.Source{}, // failing due to cloudfront protection
+		&robtex.Source{},
+		&rsecloud.Source{},
+		&scanmalware.Source{},
+		&securitytrails.Source{},
+		&shodan.Source{},
+		&shodanct.Source{},
+		&sitedossier.Source{},
+		&thc.Source{},
+		&threatbook.Source{},
+		&threatcrowd.Source{},
+		// &threatminer.Source{}, // failing  api
+		&urlscan.Source{},
+		&virustotal.Source{},
+		&waybackarchive.Source{},
+		&whoisxmlapi.Source{},
+		&windvane.Source{},
+		&zoomeyeapi.Source{},
+		&submd.Source{},
+	}
 }
 
 var sourceWarnings = mapsutil.NewSyncLockMap[string, string](
@@ -127,9 +133,13 @@ var sourceWarnings = mapsutil.NewSyncLockMap[string, string](
 
 var NameSourceMap = make(map[string]subscraping.Source, len(AllSources))
 
+var builtinSources = make(map[string]subscraping.Source, len(AllSources))
+var customSourceGates sync.Map
+
 func init() {
 	for _, currentSource := range AllSources {
 		NameSourceMap[strings.ToLower(currentSource.Name())] = currentSource
+		builtinSources[strings.ToLower(currentSource.Name())] = currentSource
 	}
 }
 
@@ -142,21 +152,115 @@ type Agent struct {
 
 // New creates a new agent for passive subdomain discovery
 func New(sourceNames, excludedSourceNames []string, useAllSources, useSourcesSupportingRecurse bool) *Agent {
-	sources := make(map[string]subscraping.Source, len(AllSources))
+	agent := selectSources(AllSources[:], NameSourceMap, sourceNames, excludedSourceNames, useAllSources, useSourcesSupportingRecurse)
+	for _, source := range agent.sources {
+		keyReq := source.KeyRequirement()
+		if keyReq == subscraping.RequiredKey || keyReq == subscraping.OptionalKey {
+			if apiKey := os.Getenv(fmt.Sprintf("%s_API_KEY", strings.ToUpper(source.Name()))); apiKey != "" {
+				source.AddApiKeys([]string{apiKey})
+			}
+		}
+	}
+	return agent
+}
+
+// NewWithProviderConfig creates independently owned built-in sources using effective
+// provider keys supplied by the caller. Registered custom sources are preserved and
+// serialized across agents. It does not read environment variables. Register custom
+// sources before constructing agents; registry mutation during enumeration is unsafe.
+func NewWithProviderConfig(sourceNames, excludedSourceNames []string, useAllSources, useSourcesSupportingRecurse bool, keys map[string][]string) *Agent {
+	available := newSources()
+	byName := make(map[string]subscraping.Source, len(available))
+	for _, source := range available {
+		byName[strings.ToLower(source.Name())] = source
+	}
+	agent := selectSources(AllSources[:], NameSourceMap, sourceNames, excludedSourceNames, useAllSources, useSourcesSupportingRecurse)
+	for i, source := range agent.sources {
+		name := strings.ToLower(source.Name())
+		providerKeys := slices.Clone(keys[name])
+		if source == builtinSources[name] {
+			source = byName[name]
+			source.AddApiKeys(providerKeys)
+		} else {
+			gate, _ := customSourceGates.LoadOrStore(name, make(chan struct{}, 1))
+			source = &serializedSource{Source: source, gate: gate.(chan struct{}), keys: providerKeys}
+		}
+		agent.sources[i] = source
+	}
+	return agent
+}
+
+// Custom sources have no cloning contract. Hold their gate through result draining
+// and statistics capture so mutable run state cannot leak between domains.
+type serializedSource struct {
+	subscraping.Source
+	gate  chan struct{}
+	mu    sync.Mutex
+	keys  []string
+	stats subscraping.Statistics
+}
+
+func (s *serializedSource) AddApiKeys(keys []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.keys = slices.Clone(keys)
+}
+
+func (s *serializedSource) Statistics() subscraping.Statistics {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stats
+}
+
+func (s *serializedSource) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
+	results := make(chan subscraping.Result)
+	go func() {
+		defer close(results)
+		select {
+		case s.gate <- struct{}{}:
+		case <-ctx.Done():
+			return
+		}
+		defer func() { <-s.gate }()
+		if ctx.Err() != nil {
+			return
+		}
+		s.mu.Lock()
+		keys := slices.Clone(s.keys)
+		s.mu.Unlock()
+		if len(keys) > 0 {
+			s.Source.AddApiKeys(keys)
+		}
+		for result := range s.Source.Run(ctx, domain, session) {
+			select {
+			case results <- result:
+			case <-ctx.Done():
+				// Keep draining custom sources that use unconditional channel sends.
+			}
+		}
+		s.mu.Lock()
+		s.stats = s.Source.Statistics()
+		s.mu.Unlock()
+	}()
+	return results
+}
+
+func selectSources(available []subscraping.Source, byName map[string]subscraping.Source, sourceNames, excludedSourceNames []string, useAllSources, useSourcesSupportingRecurse bool) *Agent {
+	sources := make(map[string]subscraping.Source, len(available))
 
 	if useAllSources {
-		maps.Copy(sources, NameSourceMap)
+		maps.Copy(sources, byName)
 	} else {
 		if len(sourceNames) > 0 {
 			for _, source := range sourceNames {
-				if NameSourceMap[source] == nil {
+				if byName[source] == nil {
 					gologger.Warning().Msgf("There is no source with the name: %s", source)
 				} else {
-					sources[source] = NameSourceMap[source]
+					sources[source] = byName[source]
 				}
 			}
 		} else {
-			for _, currentSource := range AllSources {
+			for _, currentSource := range available {
 				if currentSource.IsDefault() {
 					sources[currentSource.Name()] = currentSource
 				}
@@ -187,15 +291,6 @@ func New(sourceNames, excludedSourceNames []string, useAllSources, useSourcesSup
 	for _, currentSource := range sources {
 		if warning, ok := sourceWarnings.Get(strings.ToLower(currentSource.Name())); ok {
 			gologger.Warning().Msg(warning)
-		}
-	}
-
-	for _, source := range sources {
-		keyReq := source.KeyRequirement()
-		if keyReq == subscraping.RequiredKey || keyReq == subscraping.OptionalKey {
-			if apiKey := os.Getenv(fmt.Sprintf("%s_API_KEY", strings.ToUpper(source.Name()))); apiKey != "" {
-				source.AddApiKeys([]string{apiKey})
-			}
 		}
 	}
 

--- a/pkg/passive/workers_test.go
+++ b/pkg/passive/workers_test.go
@@ -1,0 +1,134 @@
+package passive
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+)
+
+func TestNewWithProviderConfigIsolation(t *testing.T) {
+	t.Setenv("SHODAN_API_KEY", "environment-key")
+	keys := map[string][]string{"shodan": {"first-key"}}
+	first := NewWithProviderConfig([]string{"shodan"}, nil, false, false, keys)
+	keys["shodan"][0] = "second-key"
+	second := NewWithProviderConfig([]string{"shodan"}, nil, false, false, keys)
+	keys["shodan"][0] = "changed"
+	if first.sources[0] == second.sources[0] || first.sources[0] == NameSourceMap["shodan"] {
+		t.Fatal("source instances are shared")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	limiter := testRateLimiter(t, first, 0, nil)
+	arrived := make(chan string, 2)
+	release := make(chan struct{})
+	transport := sourceRoundTripper(func(req *http.Request) (*http.Response, error) {
+		arrived <- req.URL.Query().Get("key")
+		select {
+		case <-release:
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+		domain := strings.TrimPrefix(req.URL.Path, "/dns/domain/")
+		subdomains := `["one"]`
+		if domain == "second.example" {
+			subdomains = `["one","two"]`
+		}
+		body := fmt.Sprintf(`{"domain":%q,"subdomains":%s}`, domain, subdomains)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+	})
+	channels := make([]<-chan subscraping.Result, 0, 2)
+	for i, agent := range []*Agent{first, second} {
+		domain := []string{"first.example", "second.example"}[i]
+		session, err := subscraping.NewSession(domain, "", nil, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		session.Client.Transport = transport
+		session.RequestLimiter = limiter
+		t.Cleanup(session.Close)
+		channels = append(channels, agent.sources[0].Run(context.WithValue(ctx, subscraping.CtxSourceArg, "shodan"), domain, session))
+	}
+	var observedKeys []string
+	for range 2 {
+		select {
+		case key := <-arrived:
+			observedKeys = append(observedKeys, key)
+		case <-ctx.Done():
+			t.Fatal("both sources did not enter the HTTP transport concurrently")
+		}
+	}
+	close(release)
+	slices.Sort(observedKeys)
+	if !slices.Equal(observedKeys, []string{"first-key", "second-key"}) {
+		t.Fatal("requests did not retain independently configured keys")
+	}
+	for i, channel := range channels {
+		var values []string
+		for result := range channel {
+			if result.Type == subscraping.Error {
+				t.Fatal(result.Error)
+			}
+			values = append(values, result.Value)
+		}
+		want := [][]string{{"one.first.example"}, {"one.second.example", "two.second.example"}}[i]
+		if !slices.Equal(values, want) {
+			t.Fatalf("source %d results: %v, want %v", i, values, want)
+		}
+		stats := []*Agent{first, second}[i].GetStatistics()["shodan"]
+		if stats.Requests != 1 || stats.Results != len(want) || stats.Errors != 0 || stats.Skipped {
+			t.Fatalf("source %d statistics: %+v", i, stats)
+		}
+	}
+}
+
+type sourceRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f sourceRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestNewWithProviderConfigSelection(t *testing.T) {
+	for _, recursive := range []bool{false, true} {
+		legacy := New(nil, []string{"chaos"}, true, recursive)
+		fresh := NewWithProviderConfig(nil, []string{"chaos"}, true, recursive, nil)
+		if len(legacy.sources) != len(fresh.sources) {
+			t.Fatalf("source counts differ: %d != %d", len(legacy.sources), len(fresh.sources))
+		}
+		for _, source := range fresh.sources {
+			if source.Name() == "chaos" || (recursive && !source.HasRecursiveSupport()) {
+				t.Fatalf("unexpected source %s", source.Name())
+			}
+			if source == NameSourceMap[source.Name()] {
+				t.Fatalf("shared source %s", source.Name())
+			}
+		}
+	}
+	legacy := New([]string{"chaos"}, nil, false, false)
+	if legacy.sources[0] != NameSourceMap["chaos"] {
+		t.Fatal("legacy constructor no longer uses registered source")
+	}
+}
+
+func TestEnumerationBorrowsRateLimiter(t *testing.T) {
+	agent := &Agent{sources: []subscraping.Source{&blockingSource{exited: make(chan struct{})}}}
+	limiter := testRateLimiter(t, agent, 1, nil)
+	for range agent.EnumerateSubdomains("example.com", "", 100, 1, time.Second, WithRateLimiter(limiter)) {
+	}
+	start := time.Now()
+	for i := 0; i < 3; i++ {
+		if err := limiter.Wait(context.Background(), "mock"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Three tokens must still span two refill intervals after enumeration ends.
+	if elapsed := time.Since(start); elapsed < 1500*time.Millisecond {
+		t.Fatalf("borrowed limiter no longer enforces its budget: %s", elapsed)
+	}
+}

--- a/pkg/resolve/client.go
+++ b/pkg/resolve/client.go
@@ -1,6 +1,8 @@
 package resolve
 
 import (
+	"context"
+
 	"github.com/projectdiscovery/dnsx/libs/dnsx"
 )
 
@@ -20,8 +22,56 @@ var DefaultResolvers = []string{
 
 // Resolver is a struct for resolving DNS names
 type Resolver struct {
-	DNSClient *dnsx.DNSX
-	Resolvers []string
+	DNSClient   *dnsx.DNSX
+	Resolvers   []string
+	lookupSlots chan struct{}
+}
+
+// WithConcurrencyLimit returns a copy whose pools share a worker and lookup limit.
+// The DNS client is shared; the original resolver is unchanged. Nonpositive limits use one slot.
+func (r *Resolver) WithConcurrencyLimit(limit int) *Resolver {
+	if limit < 1 {
+		limit = 1
+	}
+
+	bounded := *r
+	bounded.lookupSlots = make(chan struct{}, limit)
+
+	return &bounded
+}
+
+func (r *Resolver) lookup(ctx context.Context, host string) ([]string, error) {
+	if err := r.acquire(ctx); err != nil {
+		return nil, err
+	}
+
+	if r.lookupSlots != nil {
+		defer func() { <-r.lookupSlots }()
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// DNSX does not accept a context: an active lookup completes within its own timeout.
+	return r.DNSClient.Lookup(host)
+}
+
+func (r *Resolver) acquire(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if r.lookupSlots == nil {
+		return nil
+	}
+
+	select {
+	case r.lookupSlots <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // New creates a new resolver struct with the default resolvers

--- a/pkg/resolve/concurrency_test.go
+++ b/pkg/resolve/concurrency_test.go
@@ -1,0 +1,190 @@
+package resolve
+
+import (
+	"context"
+	"net"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/projectdiscovery/dnsx/libs/dnsx"
+)
+
+func TestSharedLimitBoundsWorkerGoroutines(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resolver := New().WithConcurrencyLimit(16)
+	before := runtime.NumGoroutine()
+	var pools []*ResolutionPool
+	for range 12 {
+		pool := resolver.NewResolutionPoolWithCtx(ctx, 16, false)
+		pools = append(pools, pool)
+		pool.Tasks <- HostEntry{Host: "example.com"}
+	}
+	// Results remain unread, so workers cannot finish while their count is checked.
+	if added := runtime.NumGoroutine() - before; added > 48 {
+		t.Errorf("added %d goroutines for 12 pools with a shared limit of 16", added)
+	}
+	cancel()
+	for _, pool := range pools {
+		close(pool.Tasks)
+		for range pool.Results {
+		}
+	}
+}
+
+func TestBoundedPoolUsesAvailableWorkers(t *testing.T) {
+	for _, limits := range [][2]int{{2, 4}, {4, 2}} {
+		ctx, cancel := context.WithCancel(context.Background())
+		resolver := New().WithConcurrencyLimit(limits[0])
+		pool := resolver.NewResolutionPoolWithCtx(ctx, limits[1], false)
+		// Receiving the third task requires the dispatcher to have started two
+		// workers. Unread results hold their slots until cancellation below.
+		for range 3 {
+			pool.Tasks <- HostEntry{Host: "example.com"}
+		}
+		if got := len(resolver.lookupSlots); got != 2 {
+			t.Errorf("global=%d pool=%d: occupied slots=%d, want 2", limits[0], limits[1], got)
+		}
+		cancel()
+		close(pool.Tasks)
+		for range pool.Results {
+		}
+	}
+}
+
+func TestCanceledLookupWait(t *testing.T) {
+	original := New()
+	bounded := original.WithConcurrencyLimit(1)
+	if original.lookupSlots != nil || bounded.DNSClient != original.DNSClient {
+		t.Fatal("bounded resolver must leave original unchanged and share DNS client")
+	}
+	bounded.lookupSlots <- struct{}{}
+	ctx, cancel := context.WithCancel(context.Background())
+	pool := bounded.NewResolutionPoolWithCtx(ctx, 1, true)
+	pool.Tasks <- HostEntry{Host: "example.com"}
+	cancel()
+	select {
+	case _, ok := <-pool.Results:
+		if ok {
+			t.Fatal("unexpected result after cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("queued lookup did not stop")
+	}
+	close(pool.Tasks)
+	if err := pool.InitWildcards("example.com"); err != context.Canceled {
+		t.Fatalf("wildcard cancellation: %v", err)
+	}
+}
+
+func TestSharedLookupLimit(t *testing.T) {
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var active, peak atomic.Int32
+	server := &dns.Server{PacketConn: conn, Handler: dns.HandlerFunc(func(w dns.ResponseWriter, req *dns.Msg) {
+		n := active.Add(1)
+		for old := peak.Load(); n > old; old = peak.Load() {
+			if peak.CompareAndSwap(old, n) {
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+		ip := "192.0.2.1"
+		if strings.HasSuffix(req.Question[0].Name, ".second.test.") {
+			ip = "192.0.2.2"
+		}
+		answer, _ := dns.NewRR(req.Question[0].Name + " 60 IN A " + ip)
+		response := new(dns.Msg)
+		response.SetReply(req)
+		response.Answer = []dns.RR{answer}
+		active.Add(-1)
+		_ = w.WriteMsg(response)
+	})}
+	go func() { _ = server.ActivateAndServe() }()
+	t.Cleanup(func() { _ = server.Shutdown() })
+	options := dnsx.DefaultOptions
+	options.BaseResolvers = []string{conn.LocalAddr().String()}
+	options.MaxRetries = 1
+	options.Hostsfile = false
+	client, err := dnsx.New(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := (&Resolver{DNSClient: client}).WithConcurrencyLimit(2)
+	pools := []*ResolutionPool{
+		resolver.NewResolutionPool(4, true),
+		resolver.NewResolutionPool(4, true),
+	}
+	done := make(chan error, 2)
+	for i, domain := range []string{"first.test", "second.test"} {
+		go func() { done <- pools[i].InitWildcards(domain) }()
+	}
+	for range pools {
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, exists := pools[0].wildcardIPs["192.0.2.2"]; exists {
+		t.Fatal("wildcard state crossed domains")
+	}
+	for _, pool := range pools {
+		go func() {
+			for range 8 {
+				pool.Tasks <- HostEntry{Host: "www.other.test"}
+			}
+			close(pool.Tasks)
+		}()
+		go func() {
+			for range pool.Results {
+			}
+			done <- nil
+		}()
+	}
+	for range pools {
+		<-done
+	}
+	if got := peak.Load(); got != 2 {
+		t.Fatalf("maximum concurrent DNS calls = %d, want 2", got)
+	}
+}
+
+func TestResolutionPoolPassthrough(t *testing.T) {
+	pool := New().NewResolutionPool(2, false)
+	go func() {
+		pool.Tasks <- HostEntry{Host: "www.example.com", Source: "test"}
+		close(pool.Tasks)
+	}()
+	var results []Result
+	for result := range pool.Results {
+		results = append(results, result)
+	}
+	if len(results) != 1 || results[0].Host != "www.example.com" || results[0].Source != "test" {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
+func TestCancellationReleasesBlockedResult(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := New().NewResolutionPoolWithCtx(ctx, 1, false)
+	pool.Tasks <- HostEntry{Host: "www.example.com"}
+	cancel()
+	close(pool.Tasks)
+	done := make(chan struct{})
+	go func() {
+		for range pool.Results {
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("canceled result send blocked pool shutdown")
+	}
+}

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -1,6 +1,7 @@
 package resolve
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -19,6 +20,7 @@ type ResolutionPool struct {
 	Results        chan Result
 	wg             *sync.WaitGroup
 	removeWildcard bool
+	ctx            context.Context
 
 	wildcardIPs map[string]struct{}
 }
@@ -52,7 +54,14 @@ const (
 
 // NewResolutionPool creates a pool of resolvers for resolving subdomains of a given domain
 func (r *Resolver) NewResolutionPool(workers int, removeWildcard bool) *ResolutionPool {
+	return r.NewResolutionPoolWithCtx(context.Background(), workers, removeWildcard)
+}
+
+// NewResolutionPoolWithCtx creates a pool that stops on cancellation.
+// Producers must also observe ctx when sending Tasks, and close Tasks when finished.
+func (r *Resolver) NewResolutionPoolWithCtx(ctx context.Context, workers int, removeWildcard bool) *ResolutionPool {
 	resolutionPool := &ResolutionPool{
+		ctx:            ctx,
 		Resolver:       r,
 		Tasks:          make(chan HostEntry),
 		Results:        make(chan Result),
@@ -62,11 +71,17 @@ func (r *Resolver) NewResolutionPool(workers int, removeWildcard bool) *Resoluti
 	}
 
 	go func() {
-		for range workers {
-			resolutionPool.wg.Add(1)
-			go resolutionPool.resolveWorker()
+		if r.lookupSlots != nil {
+			resolutionPool.dispatch(workers)
+		} else {
+			for range workers {
+				resolutionPool.wg.Add(1)
+				go resolutionPool.resolveWorker()
+			}
 		}
+
 		resolutionPool.wg.Wait()
+
 		close(resolutionPool.Results)
 	}()
 
@@ -78,7 +93,11 @@ func (r *ResolutionPool) InitWildcards(domain string) error {
 	for range maxWildcardChecks {
 		uid := xid.New().String()
 
-		hosts, _ := r.DNSClient.Lookup(uid + "." + domain)
+		hosts, _ := r.lookup(r.ctx, uid+"."+domain)
+		if err := r.ctx.Err(); err != nil {
+			return err
+		}
+
 		if len(hosts) == 0 {
 			return fmt.Errorf("%s is not a wildcard domain", domain)
 		}
@@ -88,38 +107,118 @@ func (r *ResolutionPool) InitWildcards(domain string) error {
 			r.wildcardIPs[host] = struct{}{}
 		}
 	}
+
 	return nil
 }
 
 func (r *ResolutionPool) resolveWorker() {
-	for task := range r.Tasks {
-		if !r.removeWildcard {
-			r.Results <- Result{Type: Subdomain, Host: task.Host, IP: "", Source: task.Source, WildcardCertificate: task.WildcardCertificate}
-			continue
-		}
+	defer r.wg.Done()
 
-		hosts, err := r.DNSClient.Lookup(task.Host)
-		if err != nil {
-			r.Results <- Result{Type: Error, Host: task.Host, Source: task.Source, Error: err, WildcardCertificate: task.WildcardCertificate}
-			continue
-		}
-
-		if len(hosts) == 0 {
-			continue
-		}
-
-		var skip bool
-		for _, host := range hosts {
-			// Ignore the host if it exists in wildcard ips map
-			if _, ok := r.wildcardIPs[host]; ok {
-				skip = true
-				break
+	for {
+		var task HostEntry
+		select {
+		case <-r.ctx.Done():
+			return
+		case next, ok := <-r.Tasks:
+			if !ok {
+				return
 			}
+
+			task = next
 		}
 
-		if !skip {
-			r.Results <- Result{Type: Subdomain, Host: task.Host, IP: hosts[0], Source: task.Source, WildcardCertificate: task.WildcardCertificate}
+		r.resolveTask(task)
+	}
+}
+
+// dispatch reserves capacity before starting a worker, so separate domain pools
+// do not each park a full set of workers waiting for the shared DNS limit.
+func (r *ResolutionPool) dispatch(workers int) {
+	if workers < 1 {
+		return
+	}
+
+	localSlots := make(chan struct{}, workers)
+
+	for {
+		select {
+		case <-r.ctx.Done():
+			return
+		case task, ok := <-r.Tasks:
+			if !ok {
+				return
+			}
+
+			select {
+			case localSlots <- struct{}{}:
+			case <-r.ctx.Done():
+				return
+			}
+
+			if err := r.acquire(r.ctx); err != nil {
+				return
+			}
+
+			r.wg.Add(1)
+
+			go func() {
+				defer r.wg.Done()
+				defer func() {
+					<-r.lookupSlots
+					<-localSlots
+				}()
+
+				r.resolveTask(task)
+			}()
 		}
 	}
-	r.wg.Done()
+}
+
+func (r *ResolutionPool) resolveTask(task HostEntry) {
+	if r.ctx.Err() != nil {
+		return
+	}
+
+	if !r.removeWildcard {
+		r.sendResult(Result{Type: Subdomain, Host: task.Host, IP: "", Source: task.Source, WildcardCertificate: task.WildcardCertificate})
+
+		return
+	}
+
+	// A bounded pool already holds its slot until this result is delivered.
+	hosts, err := r.DNSClient.Lookup(task.Host)
+	if err != nil {
+		r.sendResult(Result{Type: Error, Host: task.Host, Source: task.Source, Error: err, WildcardCertificate: task.WildcardCertificate})
+
+		return
+	}
+
+	if len(hosts) == 0 {
+		return
+	}
+
+	var skip bool
+	for _, host := range hosts {
+		// Ignore the host if it exists in wildcard ips map
+		if _, ok := r.wildcardIPs[host]; ok {
+			skip = true
+
+			break
+		}
+	}
+
+	if !skip {
+		r.sendResult(Result{Type: Subdomain, Host: task.Host, IP: hosts[0], Source: task.Source, WildcardCertificate: task.WildcardCertificate})
+	}
+}
+
+func (r *ResolutionPool) sendResult(result Result) {
+	if r.ctx.Err() != nil {
+		return
+	}
+
+	select {
+	case r.Results <- result:
+	case <-r.ctx.Done():
+	}
 }

--- a/pkg/runner/concurrency_active_test.go
+++ b/pkg/runner/concurrency_active_test.go
@@ -1,0 +1,143 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/projectdiscovery/dnsx/libs/dnsx"
+	"github.com/projectdiscovery/subfinder/v2/pkg/resolve"
+)
+
+func activeTestResolver(t *testing.T, handler dns.HandlerFunc) *resolve.Resolver {
+	t.Helper()
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &dns.Server{PacketConn: conn, Handler: handler}
+	go func() { _ = server.ActivateAndServe() }()
+	t.Cleanup(func() { _ = server.Shutdown() })
+	options := dnsx.DefaultOptions
+	options.BaseResolvers = []string{conn.LocalAddr().String()}
+	options.MaxRetries = 1
+	options.Hostsfile = false
+	options.Timeout = 100 * time.Millisecond
+	client, err := dnsx.New(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &resolve.Resolver{DNSClient: client}
+}
+
+func TestEnumerateMultipleDomainsActive(t *testing.T) {
+	source := &delayedSource{delay: 15 * time.Millisecond}
+	r := delayedRunner(t, 4, source)
+	r.options.RemoveWildcard = true
+	r.options.HostIP = true
+	var active, peak, probes, hosts atomic.Int32
+	r.resolverClient = activeTestResolver(t, func(w dns.ResponseWriter, request *dns.Msg) {
+		n := active.Add(1)
+		for old := peak.Load(); n > old; old = peak.Load() {
+			if peak.CompareAndSwap(old, n) {
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+		ip := "192.0.2.2"
+		if strings.HasPrefix(request.Question[0].Name, "www.") {
+			ip = "192.0.2.1"
+			if request.Question[0].Qtype == dns.TypeA {
+				hosts.Add(1)
+			}
+		} else {
+			if request.Question[0].Qtype == dns.TypeA {
+				probes.Add(1)
+			}
+		}
+		answer, _ := dns.NewRR(request.Question[0].Name + " 60 IN A " + ip)
+		response := new(dns.Msg)
+		response.SetReply(request)
+		if request.Question[0].Qtype == dns.TypeA {
+			response.Answer = []dns.RR{answer}
+		}
+		active.Add(-1)
+		_ = w.WriteMsg(response)
+	})
+	var callbacks []string
+	r.options.ResultCallback = func(entry *resolve.HostEntry) { callbacks = append(callbacks, entry.Host) }
+	var input, output strings.Builder
+	for i := range 12 {
+		fmt.Fprintf(&input, "target-%d.example\n", i)
+	}
+	if err := r.EnumerateMultipleDomainsWithCtx(context.Background(), strings.NewReader(input.String()), []io.Writer{&output}); err != nil {
+		t.Fatal(err)
+	}
+	if got := source.peak.Load(); got < 2 || got > 4 {
+		t.Fatalf("concurrent domains=%d, want 2..4", got)
+	}
+	if got := peak.Load(); got < 2 || got > 4 {
+		t.Fatalf("concurrent DNS calls=%d, want 2..4", got)
+	}
+	if probes.Load() != 36 || hosts.Load() != 12 {
+		t.Fatalf("probes=%d hosts=%d, want 36 and 12", probes.Load(), hosts.Load())
+	}
+	if len(callbacks) != 12 {
+		t.Fatalf("callbacks=%d, want 12", len(callbacks))
+	}
+	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
+	if len(lines) != 12 {
+		t.Fatalf("output lines=%d, want 12", len(lines))
+	}
+	for i := range 12 {
+		want := fmt.Sprintf("www.target-%d.example,192.0.2.1,benchmark-delay", i)
+		if !strings.Contains(output.String(), want+"\n") {
+			t.Errorf("missing output %q in %q", want, output.String())
+		}
+	}
+}
+
+func TestEnumerateMultipleDomainsActiveCancellation(t *testing.T) {
+	source := &delayedSource{delay: time.Millisecond}
+	r := delayedRunner(t, 4, source)
+	r.options.RemoveWildcard = true
+	r.options.HostIP = true
+	started := make(chan struct{}, 4)
+	r.resolverClient = activeTestResolver(t, func(_ dns.ResponseWriter, _ *dns.Msg) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		// No response: the active DNSX call must finish through its own timeout.
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- r.EnumerateMultipleDomainsWithCtx(ctx, strings.NewReader(strings.Repeat("target.example\n", 12)), nil)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("DNS query did not start")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error=%v, want context canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("active enumeration did not stop after DNS timeout")
+	}
+	if source.active.Load() != 0 {
+		t.Fatal("source still active after cancellation")
+	}
+}

--- a/pkg/runner/concurrency_test.go
+++ b/pkg/runner/concurrency_test.go
@@ -1,0 +1,321 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/passive"
+	"github.com/projectdiscovery/subfinder/v2/pkg/resolve"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+	mapsutil "github.com/projectdiscovery/utils/maps"
+)
+
+// delayedSource models a source waiting on I/O without using an external service.
+type delayedSource struct {
+	delay     time.Duration
+	active    atomic.Int64
+	peak      atomic.Int64
+	completed atomic.Int64
+	takeToken bool
+}
+
+func (s *delayedSource) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
+	results := make(chan subscraping.Result)
+	go func() {
+		defer close(results)
+		active := s.active.Add(1)
+		defer s.active.Add(-1)
+		for peak := s.peak.Load(); active > peak; peak = s.peak.Load() {
+			if s.peak.CompareAndSwap(peak, active) {
+				break
+			}
+		}
+		if s.takeToken {
+			if err := session.RequestLimiter.Wait(ctx, s.Name()); err != nil {
+				return
+			}
+		}
+		timer := time.NewTimer(s.delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		select {
+		case <-ctx.Done():
+		case results <- subscraping.Result{Type: subscraping.Subdomain, Source: s.Name(), Value: "www." + domain}:
+			s.completed.Add(1)
+		}
+	}()
+	return results
+}
+func (*delayedSource) Name() string                               { return "benchmark-delay" }
+func (*delayedSource) IsDefault() bool                            { return false }
+func (*delayedSource) HasRecursiveSupport() bool                  { return true }
+func (*delayedSource) NeedsKey() bool                             { return false }
+func (*delayedSource) KeyRequirement() subscraping.KeyRequirement { return subscraping.NoKey }
+func (*delayedSource) AddApiKeys([]string)                        {}
+func (*delayedSource) Statistics() subscraping.Statistics         { return subscraping.Statistics{} }
+
+func delayedRunner(t testing.TB, threads int, source *delayedSource) *Runner {
+	t.Helper()
+	name := source.Name()
+	previous, existed := passive.NameSourceMap[name]
+	passive.NameSourceMap[name] = source
+	t.Cleanup(func() {
+		if existed {
+			passive.NameSourceMap[name] = previous
+		} else {
+			delete(passive.NameSourceMap, name)
+		}
+	})
+	return &Runner{
+		options:         &Options{Threads: threads, Timeout: 1, MaxEnumerationTime: 1},
+		passiveAgent:    passive.New([]string{name}, nil, false, false),
+		newPassiveAgent: func() *passive.Agent { return passive.New([]string{name}, nil, false, false) },
+	}
+}
+
+// BenchmarkEnumerateMultipleDomains includes session construction, source fan-out,
+// result processing and output. Every batch contains 40 domains and each source
+// waits 5 ms, so it measures overlapping I/O waits rather than faster parsing.
+func BenchmarkEnumerateMultipleDomains(b *testing.B) {
+	var input strings.Builder
+	for i := 0; i < 40; i++ {
+		fmt.Fprintf(&input, "target-%d.example\n", i)
+	}
+	domains := input.String()
+	for _, threads := range []int{1, 4, 10} {
+		b.Run(fmt.Sprintf("threads=%d", threads), func(b *testing.B) {
+			source := &delayedSource{delay: 5 * time.Millisecond}
+			r := delayedRunner(b, threads, source)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := r.EnumerateMultipleDomainsWithCtx(context.Background(), strings.NewReader(domains), []io.Writer{io.Discard}); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			if got, want := source.completed.Load(), int64(b.N*40); got != want {
+				b.Fatalf("completed %d domains, want %d", got, want)
+			}
+			b.ReportMetric(float64(source.peak.Load()), "peak-domains")
+		})
+	}
+}
+
+func TestEnumerateMultipleDomainsConcurrency(t *testing.T) {
+	for _, threads := range []int{1, 4} {
+		t.Run(fmt.Sprintf("threads=%d", threads), func(t *testing.T) {
+			source := &delayedSource{delay: 10 * time.Millisecond}
+			r := delayedRunner(t, threads, source)
+			var output strings.Builder
+			var input strings.Builder
+			for i := 0; i < 12; i++ {
+				fmt.Fprintf(&input, "target-%d.example\n", i)
+			}
+			if err := r.EnumerateMultipleDomainsWithCtx(context.Background(), strings.NewReader(input.String()), []io.Writer{&output}); err != nil {
+				t.Fatal(err)
+			}
+			if got := source.peak.Load(); got != int64(threads) {
+				t.Errorf("peak domains=%d, want %d", got, threads)
+			}
+			if got := len(strings.Fields(output.String())); got != 12 {
+				t.Errorf("output hosts=%d, want 12", got)
+			}
+		})
+	}
+}
+
+func TestEnumerateMultipleDomainsCallbacksAndFiles(t *testing.T) {
+	for _, jsonOutput := range []bool{false, true} {
+		t.Run(fmt.Sprintf("json=%v", jsonOutput), func(t *testing.T) {
+			source := &delayedSource{delay: time.Millisecond}
+			r := delayedRunner(t, 4, source)
+			r.options.JSON = jsonOutput
+			r.options.CaptureSources = jsonOutput
+			r.options.OutputFile = filepath.Join(t.TempDir(), "all.txt")
+			var calls []string
+			r.options.ResultCallback = func(entry *resolve.HostEntry) { calls = append(calls, entry.Host) }
+			var first, second strings.Builder
+			input := "one.example\ntwo.example\none.example\nthree.example\n"
+			if err := r.EnumerateMultipleDomainsWithCtx(context.Background(), strings.NewReader(input), []io.Writer{&first, &second}); err != nil {
+				t.Fatal(err)
+			}
+			saved, err := os.ReadFile(r.options.OutputFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if first.String() != second.String() || first.String() != string(saved) {
+				t.Fatal("writers received different domain output")
+			}
+			if len(calls) != 4 {
+				t.Fatalf("callbacks=%d, want 4", len(calls))
+			}
+			lines := strings.Split(strings.TrimSpace(first.String()), "\n")
+			if len(lines) != 4 {
+				t.Fatalf("lines=%d, want 4", len(lines))
+			}
+			if jsonOutput {
+				for _, line := range lines {
+					var value map[string]any
+					if err := json.Unmarshal([]byte(line), &value); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestEnumerateMultipleDomainsDuplicateOutputDirectory(t *testing.T) {
+	source := &delayedSource{delay: time.Millisecond}
+	r := delayedRunner(t, 4, source)
+	r.options.OutputDirectory = t.TempDir()
+	if err := r.EnumerateMultipleDomainsWithCtx(context.Background(), strings.NewReader(strings.Repeat("same.example\n", 12)), nil); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(r.options.OutputDirectory, "same.example.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "www.same.example\n" {
+		t.Fatalf("corrupted repeated-domain output: %q", data)
+	}
+}
+
+func TestEnumerateMultipleDomainsSharedRateLimit(t *testing.T) {
+	source := &delayedSource{takeToken: true}
+	r := delayedRunner(t, 4, source)
+	r.rateLimit = &subscraping.CustomRateLimit{
+		Custom:         mapsutil.SyncLockMap[string, uint]{Map: map[string]uint{source.Name(): 1}},
+		CustomDuration: mapsutil.SyncLockMap[string, time.Duration]{Map: map[string]time.Duration{source.Name(): 40 * time.Millisecond}},
+	}
+	start := time.Now()
+	if err := r.EnumerateMultipleDomainsWithCtx(context.Background(), strings.NewReader("a.example\nb.example\nc.example\nd.example\ne.example\nf.example\n"), nil); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(start); elapsed < 160*time.Millisecond {
+		t.Fatalf("workers multiplied provider budget: six tokens in %s", elapsed)
+	}
+	if got := source.completed.Load(); got != 6 {
+		t.Fatalf("completed=%d, want 6", got)
+	}
+}
+
+type failedWriter struct{ err error }
+
+func (w failedWriter) Write([]byte) (int, error) { return 0, w.err }
+
+type failedReader struct{ err error }
+
+func (r failedReader) Read([]byte) (int, error) { return 0, r.err }
+
+func TestEnumerateMultipleDomainsErrors(t *testing.T) {
+	sentinel := errors.New("test I/O failure")
+	for _, test := range []struct {
+		name   string
+		reader io.Reader
+		writer io.Writer
+	}{
+		{"reader", failedReader{sentinel}, io.Discard},
+		{"writer", strings.NewReader(strings.Repeat("a.example\n", 40)), failedWriter{sentinel}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			source := &delayedSource{delay: time.Millisecond}
+			r := delayedRunner(t, 4, source)
+			err := r.EnumerateMultipleDomainsWithCtx(context.Background(), test.reader, []io.Writer{test.writer})
+			if !errors.Is(err, sentinel) {
+				t.Fatalf("error=%v, want sentinel", err)
+			}
+			if source.active.Load() != 0 {
+				t.Fatal("source still active after return")
+			}
+		})
+	}
+}
+
+func TestEnumerateMultipleDomainsCancellation(t *testing.T) {
+	source := &delayedSource{delay: time.Second}
+	r := delayedRunner(t, 4, source)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	err := r.EnumerateMultipleDomainsWithCtx(ctx, strings.NewReader(strings.Repeat("a.example\n", 40)), nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error=%v, want deadline exceeded", err)
+	}
+	if source.active.Load() != 0 {
+		t.Fatal("source still active after cancellation")
+	}
+	if source.completed.Load() != 0 {
+		t.Fatal("unexpected completed sources after cancellation")
+	}
+}
+
+func TestEnumerateMultipleDomainsThreadBounds(t *testing.T) {
+	for _, threads := range []int{-1, 0} {
+		t.Run(fmt.Sprint(threads), func(t *testing.T) {
+			source := &delayedSource{}
+			r := delayedRunner(t, threads, source)
+			err := r.EnumerateMultipleDomainsWithCtx(context.Background(), strings.NewReader("a.example\nb.example\n"), nil)
+			if threads < 0 {
+				if err == nil {
+					t.Fatal("negative threads accepted")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if source.peak.Load() != 1 {
+				t.Fatal("unset SDK threads must use one worker")
+			}
+		})
+	}
+}
+
+func TestEnumerateMultipleDomainsOutputPreflight(t *testing.T) {
+	for _, directory := range []bool{false, true} {
+		t.Run(fmt.Sprint(directory), func(t *testing.T) {
+			blocked := filepath.Join(t.TempDir(), "file")
+			if err := os.WriteFile(blocked, nil, 0600); err != nil {
+				t.Fatal(err)
+			}
+			source := &delayedSource{}
+			r := delayedRunner(t, 4, source)
+			if directory {
+				r.options.OutputDirectory = blocked
+			} else {
+				r.options.OutputFile = filepath.Join(blocked, "output.txt")
+			}
+			if err := r.EnumerateMultipleDomainsWithCtx(context.Background(), strings.NewReader("one.example\ntwo.example\n"), nil); err == nil {
+				t.Fatal("invalid output accepted")
+			}
+			if source.completed.Load() != 0 {
+				t.Fatal("provider work started before output validation")
+			}
+		})
+	}
+}
+func TestEnumerateMultipleDomainsEmptyInputDoesNotCreateOutput(t *testing.T) {
+	source := &delayedSource{}
+	r := delayedRunner(t, 4, source)
+	r.options.OutputFile = filepath.Join(t.TempDir(), "absent.txt")
+	if err := r.EnumerateMultipleDomainsWithCtx(context.Background(), strings.NewReader("\n\n"), nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(r.options.OutputFile); !os.IsNotExist(err) {
+		t.Fatalf("empty input created output: %v", err)
+	}
+}

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -18,6 +18,7 @@ func createProviderConfigYAML(configFilePath string) error {
 	if err != nil {
 		return err
 	}
+
 	defer func() {
 		if err := configFile.Close(); err != nil {
 			gologger.Error().Msgf("Error closing config file: %s", err)
@@ -38,13 +39,7 @@ func createProviderConfigYAML(configFilePath string) error {
 
 // UnmarshalFrom writes the marshaled yaml config to disk
 func UnmarshalFrom(file string) error {
-	reader, err := fileutil.SubstituteConfigFromEnvVars(file)
-	if err != nil {
-		return err
-	}
-
-	sourceApiKeysMap := map[string][]string{}
-	err = yaml.NewDecoder(reader).Decode(sourceApiKeysMap)
+	sourceApiKeysMap, err := loadProviderConfig(file)
 	for _, source := range passive.AllSources {
 		sourceName := strings.ToLower(source.Name())
 		apiKeys := sourceApiKeysMap[sourceName]
@@ -53,5 +48,18 @@ func UnmarshalFrom(file string) error {
 			source.AddApiKeys(apiKeys)
 		}
 	}
+
 	return err
+}
+
+func loadProviderConfig(file string) (map[string][]string, error) {
+	reader, err := fileutil.SubstituteConfigFromEnvVars(file)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceApiKeysMap := map[string][]string{}
+	err = yaml.NewDecoder(reader).Decode(sourceApiKeysMap)
+
+	return sourceApiKeysMap, err
 }

--- a/pkg/runner/config_concurrency_test.go
+++ b/pkg/runner/config_concurrency_test.go
@@ -1,0 +1,72 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/passive"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+)
+
+type providerSource struct {
+	delayedSource
+	keys     []string
+	observed []string
+}
+
+func (*providerSource) Name() string                               { return "testprovider" }
+func (*providerSource) KeyRequirement() subscraping.KeyRequirement { return subscraping.RequiredKey }
+func (*providerSource) NeedsKey() bool                             { return true }
+func (s *providerSource) AddApiKeys(keys []string)                 { s.keys = slices.Clone(keys) }
+func (s *providerSource) Run(_ context.Context, domain string, _ *subscraping.Session) <-chan subscraping.Result {
+	results := make(chan subscraping.Result, 1)
+	defer close(results)
+	s.observed = append(s.observed, s.keys...)
+	results <- subscraping.Result{Source: s.Name(), Value: "www." + domain}
+	return results
+}
+
+func TestRunnerProviderSnapshot(t *testing.T) {
+	source := &providerSource{}
+	old, exists := passive.NameSourceMap[source.Name()]
+	passive.NameSourceMap[source.Name()] = source
+	t.Cleanup(func() {
+		if exists {
+			passive.NameSourceMap[source.Name()] = old
+		} else {
+			delete(passive.NameSourceMap, source.Name())
+		}
+	})
+	t.Setenv("TESTPROVIDER_API_KEY", "")
+	file := filepath.Join(t.TempDir(), "providers.yaml")
+	if err := os.WriteFile(file, []byte("testprovider:\n  - file-key\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	options := &Options{Sources: []string{source.Name()}, ProviderConfig: file, Threads: 4, Timeout: 1, MaxEnumerationTime: 1}
+	first, err := NewRunner(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	options.Sources[0] = "chaos"
+	if err := os.WriteFile(file, []byte("testprovider:\n  - changed-file-key\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TESTPROVIDER_API_KEY", "environment-key")
+	second, err := NewRunner(&Options{Sources: []string{source.Name()}, ProviderConfig: file, Threads: 4, Timeout: 1, MaxEnumerationTime: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TESTPROVIDER_API_KEY", "later-environment-key")
+	for _, runner := range []*Runner{first, second, first} {
+		if err := runner.EnumerateMultipleDomainsWithCtx(context.Background(), strings.NewReader("example.com\n"), nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !slices.Equal(source.observed, []string{"file-key", "environment-key", "file-key"}) {
+		t.Fatalf("provider snapshots/precedence changed: %v", source.observed)
+	}
+}

--- a/pkg/runner/enumerate.go
+++ b/pkg/runner/enumerate.go
@@ -2,7 +2,10 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"io"
+	"os"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -40,7 +43,7 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 	// If yes, create the resolution pool and get the wildcards for the current domain
 	var resolutionPool *resolve.ResolutionPool
 	if r.options.RemoveWildcard {
-		resolutionPool = r.resolverClient.NewResolutionPool(r.options.Threads, r.options.RemoveWildcard)
+		resolutionPool = r.resolverClient.NewResolutionPoolWithCtx(ctx, max(1, r.options.Threads), r.options.RemoveWildcard)
 		err := resolutionPool.InitWildcards(domain)
 		if err != nil {
 			// Log the error but don't quit.
@@ -50,7 +53,7 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 
 	// Run the passive subdomain enumeration
 	now := time.Now()
-	passiveResults := r.passiveAgent.EnumerateSubdomainsWithCtx(ctx, domain, r.options.Proxy, r.options.RateLimit, r.options.Timeout, time.Duration(r.options.MaxEnumerationTime)*time.Minute, passive.WithCustomRateLimit(r.rateLimit), passive.WithMaxResults(r.options.MaxResults), passive.WithMaxResponseBodySize(int64(r.options.MaxResponseBodySize)))
+	passiveResults := r.passiveAgent.EnumerateSubdomainsWithCtx(ctx, domain, r.options.Proxy, r.options.RateLimit, r.options.Timeout, time.Duration(r.options.MaxEnumerationTime)*time.Minute, passive.WithCustomRateLimit(r.rateLimit), passive.WithMaxResults(r.options.MaxResults), passive.WithMaxResponseBodySize(int64(r.options.MaxResponseBodySize)), passive.WithRateLimiter(r.sharedRateLimiter))
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
@@ -62,6 +65,10 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 	// Process the results in a separate goroutine
 	go func() {
 		for result := range passiveResults {
+			if ctx.Err() != nil {
+				continue
+			}
+
 			switch result.Type {
 			case subscraping.Error:
 				gologger.Warning().Msgf("Encountered an error with source %s: %s\n", result.Source, result.Error)
@@ -113,7 +120,10 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 					// queue. Otherwise, if mode is not verbose print the results on
 					// the screen as they are discovered.
 					if r.options.RemoveWildcard {
-						resolutionPool.Tasks <- hostEntry
+						select {
+						case resolutionPool.Tasks <- hostEntry:
+						case <-ctx.Done():
+						}
 					}
 				}
 			}
@@ -145,7 +155,11 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 				}
 			}
 		}
+	}
 
+	wg.Wait()
+
+	if r.options.RemoveWildcard {
 		// Merge wildcard certificate information from uniqueMap into foundResults
 		// This handles cases where a later source marked a subdomain as wildcard
 		// after it was already sent to the resolution pool
@@ -156,10 +170,45 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 			}
 		}
 	}
-	wg.Wait()
+
+	if r.outputMu != nil {
+		r.outputMu.Lock()
+		defer r.outputMu.Unlock()
+	}
+
 	outputWriter := NewOutputWriter(r.options.JSON)
+
+	var file *os.File
+
+	if r.domainOutput {
+		filename := r.options.OutputFile
+		appendToFile := filename != ""
+		if filename == "" && r.options.OutputDirectory != "" {
+			filename = path.Join(r.options.OutputDirectory, domain)
+			if r.options.JSON {
+				filename += ".json"
+			} else {
+				filename += ".txt"
+			}
+		}
+
+		if filename != "" {
+			var err error
+
+			file, err = outputWriter.createFile(filename, appendToFile)
+			if err != nil {
+				return nil, err
+			}
+
+			// Each domain owns its writer slice. File creation and all writes are
+			// serialized, including repeated domains targeting the same output path.
+			writers = append(append([]io.Writer(nil), writers...), file)
+		}
+	}
+
 	// Now output all results in output writers
 	var err error
+
 	for _, writer := range writers {
 		if r.options.HostIP {
 			err = outputWriter.WriteHostIP(domain, foundResults, writer)
@@ -174,8 +223,19 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 				}
 			}
 		}
+
 		if err != nil {
 			gologger.Error().Msgf("Could not write results for %s: %s\n", domain, err)
+			if file != nil {
+				err = errors.Join(err, file.Close())
+			}
+
+			return nil, err
+		}
+	}
+
+	if file != nil {
+		if err := file.Close(); err != nil {
 			return nil, err
 		}
 	}
@@ -203,6 +263,7 @@ func (r *Runner) EnumerateSingleDomainWithCtx(ctx context.Context, domain string
 				statistics[source] = stat
 			}
 		}
+
 		printStatistics(statistics)
 	}
 
@@ -217,6 +278,7 @@ func (r *Runner) filterAndMatchSubdomain(subdomain string) bool {
 			}
 		}
 	}
+
 	if r.options.matchRegexes != nil {
 		for _, match := range r.options.matchRegexes {
 			if m := match.MatchString(subdomain); m {
@@ -225,5 +287,6 @@ func (r *Runner) filterAndMatchSubdomain(subdomain string) bool {
 		}
 		return false
 	}
+
 	return true
 }

--- a/pkg/runner/initialize.go
+++ b/pkg/runner/initialize.go
@@ -2,16 +2,40 @@ package runner
 
 import (
 	"net"
+	"os"
+	"slices"
 	"strings"
 
 	"github.com/projectdiscovery/dnsx/libs/dnsx"
 	"github.com/projectdiscovery/subfinder/v2/pkg/passive"
 	"github.com/projectdiscovery/subfinder/v2/pkg/resolve"
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
 )
 
 // initializePassiveEngine creates the passive engine and loads sources etc
-func (r *Runner) initializePassiveEngine() {
-	r.passiveAgent = passive.New(r.options.Sources, r.options.ExcludeSources, r.options.All, r.options.OnlyRecursive)
+func (r *Runner) initializePassiveEngine(providerKeys map[string][]string) {
+	// Snapshot credentials and selection once. Workers own fresh adapters, not
+	// copies of the global sources or their mutable enumeration state.
+	keys := make(map[string][]string, len(providerKeys))
+	for name, values := range providerKeys {
+		keys[name] = slices.Clone(values)
+	}
+
+	for _, source := range passive.NameSourceMap {
+		requirement := source.KeyRequirement()
+		if requirement == subscraping.RequiredKey || requirement == subscraping.OptionalKey {
+			if value := os.Getenv(strings.ToUpper(source.Name()) + "_API_KEY"); value != "" {
+				keys[strings.ToLower(source.Name())] = []string{value}
+			}
+		}
+	}
+
+	sources, excluded := slices.Clone(r.options.Sources), slices.Clone(r.options.ExcludeSources)
+	all, recursive := r.options.All, r.options.OnlyRecursive
+	r.newPassiveAgent = func() *passive.Agent {
+		return passive.NewWithProviderConfig(sources, excluded, all, recursive, keys)
+	}
+	r.passiveAgent = r.newPassiveAgent()
 }
 
 // initializeResolver creates the resolver used to resolve the found subdomains

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -46,7 +46,7 @@ type Options struct {
 	OnlyRecursive      bool                // Recursive specifies whether to use only recursive subdomain enumeration sources
 	All                bool                // All specifies whether to use all (slow) sources.
 	Statistics         bool                // Statistics specifies whether to report source statistics
-	Threads            int                 // Threads controls the number of threads to use for active enumerations
+	Threads            int                 // Threads bounds concurrent domains and total active DNS lookups
 	Timeout            int                 // Timeout is the seconds to wait for sources to respond
 	MaxEnumerationTime int                 // MaxEnumerationTime is the maximum amount of time in minutes to wait for enumeration
 	Domain             goflags.StringSlice // Domain is the domain to find subdomains for
@@ -115,7 +115,7 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("rate-limit", "Rate-limit",
 		flagSet.IntVarP(&options.RateLimit, "rate-limit", "rl", 0, "maximum number of http requests to send per second (global)"),
 		flagSet.RateLimitMapVarP(&options.RateLimits, "rate-limits", "rls", defaultRateLimits, "maximum number of http requests to send per second for providers in key=value format (-rls hackertarget=10/m)", goflags.NormalizedStringSliceOptions),
-		flagSet.IntVar(&options.Threads, "t", 10, "number of concurrent goroutines for resolving (-active only)"),
+		flagSet.IntVar(&options.Threads, "t", 10, "maximum concurrent domains and active DNS lookups"),
 	)
 
 	flagSet.CreateGroup("update", "Update",
@@ -222,7 +222,7 @@ func ParseOptions() *Options {
 }
 
 // loadProvidersFrom runs the app with source config
-func (options *Options) loadProvidersFrom(location string) {
+func (options *Options) loadProvidersFrom(location string) map[string][]string {
 	// todo: move elsewhere
 	if len(options.Resolvers) == 0 {
 		options.Resolvers = resolve.DefaultResolvers
@@ -230,9 +230,11 @@ func (options *Options) loadProvidersFrom(location string) {
 
 	// We skip bailing out if file doesn't exist because we'll create it
 	// at the end of options parsing from default via goflags.
-	if err := UnmarshalFrom(location); err != nil && (!strings.Contains(err.Error(), "file doesn't exist") || errors.Is(err, os.ErrNotExist)) {
+	keys, err := loadProviderConfig(location)
+	if err != nil && (!strings.Contains(err.Error(), "file doesn't exist") || errors.Is(err, os.ErrNotExist)) {
 		gologger.Error().Msgf("Could not read providers from %s: %s\n", location, err)
 	}
+	return keys
 }
 
 var keyRequirementLabels = map[subscraping.KeyRequirement]string{

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -133,7 +133,7 @@ func (r *Runner) EnumerateMultipleDomains(reader io.Reader, writers []io.Writer)
 // Completed domains are written together; domain output order is unspecified.
 func (r *Runner) EnumerateMultipleDomainsWithCtx(ctx context.Context, reader io.Reader, writers []io.Writer) (err error) {
 	if r.options.Threads < 0 {
-		return fmt.Errorf("threads must be positive")
+		return errors.New("threads must not be negative")
 	}
 	// SDK callers historically could leave Threads unset for passive enumeration.
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -3,6 +3,8 @@ package runner
 import (
 	"bufio"
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"math"
 	"os"
@@ -10,6 +12,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/projectdiscovery/gologger"
@@ -25,10 +28,14 @@ import (
 // Runner is an instance of the subdomain enumeration
 // client used to orchestrate the whole process.
 type Runner struct {
-	options        *Options
-	passiveAgent   *passive.Agent
-	resolverClient *resolve.Resolver
-	rateLimit      *subscraping.CustomRateLimit
+	options           *Options
+	passiveAgent      *passive.Agent
+	resolverClient    *resolve.Resolver
+	rateLimit         *subscraping.CustomRateLimit
+	newPassiveAgent   func() *passive.Agent
+	sharedRateLimiter subscraping.RequestLimiter
+	outputMu          *sync.Mutex
+	domainOutput      bool
 }
 
 // NewRunner creates a new runner struct instance by parsing
@@ -38,18 +45,20 @@ func NewRunner(options *Options) (*Runner, error) {
 	options.ConfigureOutput()
 	runner := &Runner{options: options}
 
+	var providerKeys map[string][]string
+
 	// Check if the application loading with any provider configuration, then take it
 	// Otherwise load the default provider config
 	if fileutil.FileExists(options.ProviderConfig) {
 		gologger.Info().Msgf("Loading provider config from %s", options.ProviderConfig)
-		options.loadProvidersFrom(options.ProviderConfig)
+		providerKeys = options.loadProvidersFrom(options.ProviderConfig)
 	} else {
 		gologger.Info().Msgf("Loading provider config from the default location: %s", defaultProviderConfigLocation)
-		options.loadProvidersFrom(defaultProviderConfigLocation)
+		providerKeys = options.loadProvidersFrom(defaultProviderConfigLocation)
 	}
 
 	// Initialize the passive subdomain enumeration engine
-	runner.initializePassiveEngine()
+	runner.initializePassiveEngine(providerKeys)
 
 	// Initialize the subdomain resolver
 	err := runner.initializeResolver()
@@ -120,63 +129,143 @@ func (r *Runner) EnumerateMultipleDomains(reader io.Reader, writers []io.Writer)
 	return r.EnumerateMultipleDomainsWithCtx(ctx, reader, writers)
 }
 
-// EnumerateMultipleDomainsWithCtx enumerates subdomains for multiple domains
-// We keep enumerating subdomains for a given domain until we reach an error
-func (r *Runner) EnumerateMultipleDomainsWithCtx(ctx context.Context, reader io.Reader, writers []io.Writer) error {
-	var err error
-	scanner := bufio.NewScanner(reader)
-	ip, _ := regexp.Compile(`^([0-9\.]+$)`)
-	for scanner.Scan() {
-		domain := preprocessDomain(scanner.Text())
-		domain = replacer.Replace(domain)
+// EnumerateMultipleDomainsWithCtx enumerates at most Threads domains concurrently.
+// Completed domains are written together; domain output order is unspecified.
+func (r *Runner) EnumerateMultipleDomainsWithCtx(ctx context.Context, reader io.Reader, writers []io.Writer) (err error) {
+	if r.options.Threads < 0 {
+		return fmt.Errorf("threads must be positive")
+	}
+	// SDK callers historically could leave Threads unset for passive enumeration.
 
-		if domain == "" || (r.options.ExcludeIps && ip.MatchString(domain)) {
+	workers := max(1, r.options.Threads)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	limiter, err := r.passiveAgent.NewRateLimiter(ctx, r.options.RateLimit, r.rateLimit)
+	if err != nil {
+		return fmt.Errorf("create batch rate limiter: %w", err)
+	}
+	defer func() {
+		if closeErr := limiter.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close batch rate limiter: %w", closeErr))
+		}
+	}()
+
+	batch := *r
+	options := *r.options
+	batch.options = &options
+	batch.sharedRateLimiter = limiter
+	batch.outputMu = &sync.Mutex{}
+	batch.domainOutput = true
+
+	if options.RemoveWildcard {
+		batch.resolverClient = r.resolverClient.WithConcurrencyLimit(workers)
+	}
+
+	if callback := options.ResultCallback; callback != nil {
+		options.ResultCallback = func(entry *resolve.HostEntry) {
+			batch.outputMu.Lock()
+			defer batch.outputMu.Unlock()
+			callback(entry)
+		}
+	}
+
+	var sharedFile *os.File
+	defer func() {
+		if sharedFile != nil {
+			err = errors.Join(err, sharedFile.Close())
+		}
+	}()
+
+	jobs := make(chan string)
+
+	var wg sync.WaitGroup
+	var firstError error
+	var errorOnce sync.Once
+
+	fail := func(err error) {
+		errorOnce.Do(func() { firstError = err; cancel() })
+	}
+
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for domain := range jobs {
+				if ctx.Err() != nil {
+					return
+				}
+
+				worker := batch
+				worker.passiveAgent = r.newPassiveAgent()
+
+				if _, err := worker.EnumerateSingleDomainWithCtx(ctx, domain, writers); err != nil {
+					fail(err)
+					return
+				}
+			}
+		}()
+	}
+
+	scanner := bufio.NewScanner(reader)
+	ip := regexp.MustCompile(`^([0-9\.]+$)`)
+
+scan:
+	for ctx.Err() == nil && scanner.Scan() {
+		domain := replacer.Replace(preprocessDomain(scanner.Text()))
+		if domain == "" || (options.ExcludeIps && ip.MatchString(domain)) {
 			continue
 		}
 
-		var file *os.File
-		// If the user has specified an output file, use that output file instead
-		// of creating a new output file for each domain. Else create a new file
-		// for each domain in the directory.
-		if r.options.OutputFile != "" {
-			outputWriter := NewOutputWriter(r.options.JSON)
-			file, err = outputWriter.createFile(r.options.OutputFile, true)
+		// Validate destinations before spending provider requests. Open the shared
+		// output only after the first accepted domain so empty input has no effects.
+		if options.OutputFile != "" && sharedFile == nil {
+			sharedFile, err = NewOutputWriter(options.JSON).createFile(options.OutputFile, true)
 			if err != nil {
-				gologger.Error().Msgf("Could not create file %s for %s: %s\n", r.options.OutputFile, r.options.Domain, err)
-				return err
+				fail(err)
+				break
 			}
 
-			_, err = r.EnumerateSingleDomainWithCtx(ctx, domain, append(writers, file))
-
-			if closeErr := file.Close(); closeErr != nil {
-				gologger.Error().Msgf("Error closing file %s: %s", r.options.OutputFile, closeErr)
-			}
-		} else if r.options.OutputDirectory != "" {
-			outputFile := path.Join(r.options.OutputDirectory, domain)
-			if r.options.JSON {
-				outputFile += ".json"
-			} else {
-				outputFile += ".txt"
+			writers = append(append([]io.Writer(nil), writers...), sharedFile)
+			batch.domainOutput = false
+		} else if options.OutputFile == "" && options.OutputDirectory != "" {
+			suffix := ".txt"
+			if options.JSON {
+				suffix = ".json"
 			}
 
-			outputWriter := NewOutputWriter(r.options.JSON)
-			file, err = outputWriter.createFile(outputFile, false)
-			if err != nil {
-				gologger.Error().Msgf("Could not create file %s for %s: %s\n", r.options.OutputFile, r.options.Domain, err)
-				return err
+			batch.outputMu.Lock()
+
+			file, openErr := NewOutputWriter(options.JSON).createFile(path.Join(options.OutputDirectory, domain+suffix), true)
+			if openErr == nil {
+				openErr = file.Close()
 			}
 
-			_, err = r.EnumerateSingleDomainWithCtx(ctx, domain, append(writers, file))
+			batch.outputMu.Unlock()
 
-			if closeErr := file.Close(); closeErr != nil {
-				gologger.Error().Msgf("Error closing file %s: %s", outputFile, closeErr)
+			if openErr != nil {
+				fail(openErr)
+				break
 			}
-		} else {
-			_, err = r.EnumerateSingleDomainWithCtx(ctx, domain, writers)
 		}
-		if err != nil {
-			return err
+
+		select {
+		case <-ctx.Done():
+			break scan
+		case jobs <- domain:
 		}
 	}
-	return nil
+
+	if err := scanner.Err(); err != nil {
+		fail(fmt.Errorf("read domains: %w", err))
+	}
+
+	close(jobs)
+	wg.Wait()
+
+	if firstError != nil {
+		return firstError
+	}
+
+	return ctx.Err()
 }

--- a/pkg/runner/validate.go
+++ b/pkg/runner/validate.go
@@ -28,9 +28,10 @@ func (options *Options) validateOptions() error {
 	}
 
 	// Validate threads and options
-	if options.Threads == 0 {
-		return errors.New("threads cannot be zero")
+	if options.Threads <= 0 {
+		return errors.New("threads must be positive")
 	}
+
 	if options.Timeout == 0 {
 		return errors.New("timeout cannot be zero")
 	}

--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -128,7 +128,14 @@ func (s *Session) HTTPRequest(ctx context.Context, method, requestURL, cookies s
 	}
 
 	sourceName := ctx.Value(CtxSourceArg).(string)
-	mrlErr := s.MultiRateLimiter.Take(sourceName)
+
+	var mrlErr error
+	if s.RequestLimiter != nil {
+		mrlErr = s.RequestLimiter.Wait(ctx, sourceName)
+	} else {
+		mrlErr = s.MultiRateLimiter.Take(sourceName)
+	}
+
 	if mrlErr != nil {
 		return nil, mrlErr
 	}
@@ -152,7 +159,10 @@ func (s *Session) DiscardHTTPResponse(response *http.Response) {
 
 // Close the session
 func (s *Session) Close() {
-	s.MultiRateLimiter.Stop()
+	if s.MultiRateLimiter != nil {
+		s.MultiRateLimiter.Stop()
+	}
+
 	s.Client.CloseIdleConnections()
 }
 

--- a/pkg/subscraping/types.go
+++ b/pkg/subscraping/types.go
@@ -81,6 +81,11 @@ type SubdomainExtractor interface {
 	Extract(text string) []string
 }
 
+// RequestLimiter waits for permission to send a source request.
+type RequestLimiter interface {
+	Wait(context.Context, string) error
+}
+
 // Session is the option passed to the source, an option is created
 // uniquely for each source.
 type Session struct {
@@ -90,6 +95,9 @@ type Session struct {
 	Client *http.Client
 	// Rate limit instance
 	MultiRateLimiter *ratelimit.MultiLimiter
+	// RequestLimiter, when set, replaces MultiRateLimiter for HTTP requests.
+	// Its lifetime belongs to the caller and may span multiple sessions.
+	RequestLimiter RequestLimiter
 	// Timeout is the timeout in seconds for requests
 	Timeout int
 	// MaxResults is the maximum number of results a source should emit


### PR DESCRIPTION
## Proposed changes

Process domain lists with a worker pool bounded by Options.Threads.
Sources already run concurrently within each domain, but the runner
used to wait for every source to finish before starting the next one.
Reuse -t so those waits can overlap instead of adding another flag.
Default stays at 10; -t 1 keeps the old sequential domain behavior.

Create a fresh built-in source instance per domain. Snapshot source
selection plus provider-file and environment keys when the runner is
constructed, and keep environment-key precedence. That way mutable
source state and stats stay isolated across concurrent enumerations.

Preserve registered custom sources and overrides. Serialize their runs
by source name, drain results on cancel, and capture stats before
releasing the source. Custom sources without explicit keys keep the
registered instance's shared config. Leave the legacy passive
constructor and provider-loading API in place.

Share provider budgets across the whole batch instead of handing every
domain a fresh request burst. Built-in sources get cancellable
fixed-window waits, with no background timers for unlimited entries.
Keep per-source overrides of the global rate setting. Custom sources
share one legacy limiter so direct Session.MultiRateLimiter users still
work, including the existing blocking wait. Sessions borrow shared
budgets and do not stop them when a domain finishes.

Apply -t to the aggregate active DNS workload, including wildcard
probes. Reserve shared capacity before spinning up resolution task
goroutines so we don't create Threads workers for every concurrent
domain. Watch cancellation while waiting for capacity, receiving tasks,
and sending results. Keep wildcard state local to each domain and wait
for passive result processing before merging wildcard metadata.

Serialize callbacks and complete-domain output writes. Validate output
paths before any provider work starts, open shared output once on the
first accepted domain, and serialize file creation for repeated domain
paths. Leave output alone when input is empty. Return scanner errors,
preserve write and close errors, and cancel pending work on the first
failure. Domain output order is unspecified.

Reject nonpositive CLI thread counts, but keep a one-worker fallback
for SDK callers that leave Threads unset. Document the expanded -t
behavior and the built-in vs custom-source config boundaries.

Add a benchmark before touching the scheduler, plus regression tests
for concurrency bounds, cancellation, shared budgets, source and
credential isolation, custom-source compatibility, DNS worker growth,
callbacks, output files, and input errors.

### Proof

For 40 domains with a simulated 5 ms source wait, median batch times
over five runs on Go 1.26.5 linux/amd64 were:

    Threads       Before       After
          1     225.35 ms    219.20 ms
          4     225.22 ms     55.43 ms
         10     227.32 ms     22.63 ms

All domains completed and peak concurrency matched the requested bound.
At Threads=10, allocated bytes went from about 643 KB to 720 KB per
batch. This benchmark only measures scheduling with a mock source; it
does not measure production source construction or live provider
throughput.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/subfinder/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-domain enumeration now runs concurrently with shared rate-limit controls.
  * Added cancellation support across enumeration, HTTP requests, and DNS lookups.
  * Added configurable DNS concurrency limits.
  * Provider credentials and source configurations remain isolated between runner instances.
  * Supports separate output files for each domain with synchronized writing.
  * Added reusable request limiters across enumerations.
  * Added configurable passive-source provider settings.

* **Bug Fixes**
  * Invalid thread counts are now rejected consistently.
  * Canceled operations stop promptly and clean up active work.
  * Output files are no longer created for invalid or empty input.
  * DNS and source processing now respect cancellation more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->