### PR TITLE
chore(subscraping): restore HTTP connection reuse

### DIFF
--- a/pkg/passive/connection_linux_test.go
+++ b/pkg/passive/connection_linux_test.go
@@ -1,0 +1,99 @@
+package passive
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/subfinder/v2/pkg/subscraping"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnumerationReleasesConnections guards against descriptor accumulation
+// across domains. The child process isolates the descriptor limit from other tests.
+func TestEnumerationReleasesConnections(t *testing.T) {
+	const childEnv = "SUBFINDER_TEST_ENUMERATION_FD_CHILD"
+	if os.Getenv(childEnv) != "1" {
+		executable, err := os.Executable()
+		require.NoError(t, err)
+		cmd := exec.CommandContext(t.Context(), executable, "-test.run=^TestEnumerationReleasesConnections$", "-test.timeout=20s")
+		cmd.Env = append(os.Environ(), childEnv+"=1")
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, "descriptor-limited enumeration failed:\n%s", output)
+		return
+	}
+
+	var limit syscall.Rlimit
+	require.NoError(t, syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit))
+	limit.Cur = min(limit.Cur, 64)
+	require.NoError(t, syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit))
+
+	var connections atomic.Int64
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "result\n")
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connections.Add(1)
+		}
+	}
+	server.Start()
+	t.Cleanup(server.Close)
+	agent := &Agent{sources: []subscraping.Source{&connectionSource{url: server.URL}}}
+	const domains = 128
+	for i := range domains {
+		domain := fmt.Sprintf("domain-%d.example", i)
+		var enumerationErr error
+		var results int
+		for result := range agent.EnumerateSubdomainsWithCtx(t.Context(), domain, "", 0, 2, 5*time.Second) {
+			if result.Type == subscraping.Error {
+				enumerationErr = result.Error
+			} else {
+				results++
+			}
+		}
+		require.NoError(t, enumerationErr, "enumerating %s", domain)
+		require.Equal(t, 2, results, "enumerating %s", domain)
+	}
+	require.Equal(t, int64(domains), connections.Load(), "each domain must reuse its connection")
+}
+
+type connectionSource struct {
+	url string
+}
+
+func (s *connectionSource) Run(ctx context.Context, domain string, session *subscraping.Session) <-chan subscraping.Result {
+	results := make(chan subscraping.Result)
+	go func() {
+		defer close(results)
+		for i := range 2 {
+			response, err := session.SimpleGet(ctx, s.url)
+			session.DiscardHTTPResponse(response)
+			if err != nil {
+				results <- subscraping.Result{Type: subscraping.Error, Source: s.Name(), Error: err}
+				return
+			}
+			results <- subscraping.Result{Type: subscraping.Subdomain, Source: s.Name(), Value: fmt.Sprintf("host%d.%s", i, domain)}
+		}
+	}()
+	return results
+}
+
+func (s *connectionSource) Name() string                       { return "connection-test" }
+func (s *connectionSource) IsDefault() bool                    { return false }
+func (s *connectionSource) HasRecursiveSupport() bool          { return false }
+func (s *connectionSource) NeedsKey() bool                     { return false }
+func (s *connectionSource) AddApiKeys(_ []string)              {}
+func (s *connectionSource) Statistics() subscraping.Statistics { return subscraping.Statistics{} }
+func (s *connectionSource) KeyRequirement() subscraping.KeyRequirement {
+	return subscraping.NoKey
+}

--- a/pkg/subscraping/agent.go
+++ b/pkg/subscraping/agent.go
@@ -47,6 +47,7 @@ func NewSession(domain string, proxy string, multiRateLimiter *ratelimit.MultiLi
 	Transport := &http.Transport{
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 100,
+		IdleConnTimeout:     90 * time.Second,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
@@ -113,7 +114,6 @@ func (s *Session) HTTPRequest(ctx context.Context, method, requestURL, cookies s
 	req.Header.Set("User-Agent", uarand.GetRandom())
 	req.Header.Set("Accept", "*/*")
 	req.Header.Set("Accept-Language", "en")
-	req.Header.Set("Connection", "close")
 
 	if basicAuth.Username != "" || basicAuth.Password != "" {
 		req.SetBasicAuth(basicAuth.Username, basicAuth.Password)

--- a/pkg/subscraping/agent_connection_test.go
+++ b/pkg/subscraping/agent_connection_test.go
@@ -1,0 +1,139 @@
+package subscraping
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/ratelimit"
+	"github.com/stretchr/testify/require"
+)
+
+func newConnectionTestSession(tb testing.TB) (*Session, context.Context) {
+	tb.Helper()
+	ctx := context.WithValue(tb.Context(), CtxSourceArg, "test")
+	limiter, err := ratelimit.NewMultiLimiter(ctx, &ratelimit.Options{Key: "test", IsUnlimited: true})
+	require.NoError(tb, err)
+	session, err := NewSession("example.com", "", limiter, 5)
+	if err != nil {
+		limiter.Stop()
+	}
+	require.NoError(tb, err)
+	tb.Cleanup(session.Close)
+	return session, ctx
+}
+
+// BenchmarkSessionConnectionReuse includes connection establishment in the first
+// request and measures successive page requests through the same session.
+func BenchmarkSessionConnectionReuse(b *testing.B) {
+	for _, protocol := range []string{"HTTP", "HTTPS"} {
+		b.Run(protocol, func(b *testing.B) {
+			var connections atomic.Int64
+			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = io.WriteString(w, "a.example.com\n")
+			}))
+			server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+				if state == http.StateNew {
+					connections.Add(1)
+				}
+			}
+			if protocol == "HTTPS" {
+				server.StartTLS()
+			} else {
+				server.Start()
+			}
+			b.Cleanup(server.Close)
+			session, ctx := newConnectionTestSession(b)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				response, err := session.SimpleGet(ctx, server.URL)
+				if err != nil {
+					b.Fatal(err)
+				}
+				session.DiscardHTTPResponse(response)
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(connections.Load())/float64(b.N), "connections/op")
+		})
+	}
+}
+
+func TestSessionConnectionReuse(t *testing.T) {
+	for _, protocol := range []string{"HTTP", "HTTPS"} {
+		for _, explicitClose := range []bool{false, true} {
+			name := protocol + "/default"
+			if explicitClose {
+				name = protocol + "/explicit-close"
+			}
+			t.Run(name, func(t *testing.T) {
+				var connections atomic.Int64
+				server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					_, _ = io.WriteString(w, "a.example.com\n")
+				}))
+				server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+					if state == http.StateNew {
+						connections.Add(1)
+					}
+				}
+				if protocol == "HTTPS" {
+					server.StartTLS()
+				} else {
+					server.Start()
+				}
+				t.Cleanup(server.Close)
+				session, ctx := newConnectionTestSession(t)
+				var headers map[string]string
+				if explicitClose {
+					headers = map[string]string{"Connection": "close"}
+				}
+				const requests = 3
+				for range requests {
+					response, err := session.Get(ctx, server.URL, "", headers)
+					require.NoError(t, err)
+					body, err := io.ReadAll(response.Body)
+					session.DiscardHTTPResponse(response)
+					require.NoError(t, err)
+					require.Equal(t, "a.example.com\n", string(body))
+				}
+				wantConnections := int64(1)
+				if explicitClose {
+					wantConnections = requests
+				}
+				require.Equal(t, wantConnections, connections.Load())
+			})
+		}
+	}
+}
+
+func TestSessionIdleConnectionLifecycle(t *testing.T) {
+	closed := make(chan struct{})
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "a.example.com\n")
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateClosed {
+			close(closed)
+		}
+	}
+	server.Start()
+	t.Cleanup(server.Close)
+	session, ctx := newConnectionTestSession(t)
+	transport := session.Client.Transport.(*http.Transport)
+	require.Positive(t, transport.IdleConnTimeout, "unused pooled connections must expire")
+
+	response, err := session.SimpleGet(ctx, server.URL)
+	require.NoError(t, err)
+	session.DiscardHTTPResponse(response)
+	session.Close()
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("session close did not release its idle connection")
+	}
+}


### PR DESCRIPTION
## Proposed changes

Drop the default Connection: close header so follow-up requests to the
same host can reuse a session's connection pool. That skips repeating
TCP setup and TLS handshakes on paginated sources. Explicit Connection
headers from sources still win.

The header landed in b03f0933d16a to stop descriptor exhaustion from
#250. Set IdleConnTimeout to 90s to match Go's default transport and
bound how long idle conns stick around. Existing Session.Close cleanup
still drains the pool when enumeration finishes.

Add HTTP and HTTPS regression tests for reuse, explicit close overrides,
and session cleanup. Add a Linux subprocess test that enumerates 128
domains under a 64-descriptor cap, makes two requests per domain, and
checks that each pair shares one connection. Disable enumeration's
session cleanup via a test overlay and the same test dies on the 30th
domain with "too many open files".

Add a benchmark for successive session requests, including connection
counts and allocations.

### Proof

Median of five runs of 500 requests against a
local server:

                         before       after
    HTTP ns/op           197234       82625
    HTTPS ns/op         2871946       88933
    HTTP allocs/op          145          80
    HTTPS allocs/op         929          85
    connections/run         500           1

These numbers are local repeated requests, not full enumeration
throughput.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/subfinder/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTTP connection reuse and lifecycle handling during passive enumeration.
  - Requests now retain reusable connections by default, while idle connections are released after a configured timeout.

- **Tests**
  - Added coverage validating connection reuse, explicit connection closure, and cleanup of idle connections.
  - Added Linux-specific coverage for large domain enumerations to ensure requests complete without connection-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->