### PR TITLE
test(subscraping): add hyphenated and delimiter-bounded subdomain extraction specs

### DIFF
--- a/pkg/subscraping/extractor_test.go
+++ b/pkg/subscraping/extractor_test.go
@@ -73,6 +73,18 @@ func TestRegexSubdomainExtractor_Extract(t *testing.T) {
 			text:   "notexample.com",
 			want:   nil,
 		},
+		{
+			name:   "hyphenated subdomain and numeric labels",
+			domain: "example.com",
+			text:   "api-v2.staging-01.example.com",
+			want:   []string{"api-v2.staging-01.example.com"},
+		},
+		{
+			name:   "comma and parenthesis bounded candidates",
+			domain: "example.com",
+			text:   "(sub1.example.com,sub2.example.com)",
+			want:   []string{"sub1.example.com", "sub2.example.com"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Extends test cases in `pkg/subscraping/extractor_test.go` to ensure `RegexSubdomainExtractor` accurately handles multi-level hyphenated subdomains containing numeric components (e.g., `api-v2.staging-01.example.com`).
- Adds explicit boundary verification for subdomain candidates embedded within punctuation delimiters (parentheses, commas).

### Testing
- Validates that extractor properly parses delimited candidates without extraneous surrounding symbols.