### PR TITLE
test(subscraping): add underscore prefixed SRV records and bracket delimited specs

### DIFF
--- a/pkg/subscraping/extractor_test.go
+++ b/pkg/subscraping/extractor_test.go
@@ -73,6 +73,18 @@ func TestRegexSubdomainExtractor_Extract(t *testing.T) {
 			text:   "notexample.com",
 			want:   nil,
 		},
+		{
+			name:   "underscore in service record subdomains",
+			domain: "example.com",
+			text:   "_sip._tcp.example.com",
+			want:   []string{"_sip._tcp.example.com"},
+		},
+		{
+			name:   "subdomains embedded in json or array brackets",
+			domain: "example.com",
+			text:   "[\"app.example.com\",\"admin.example.com\"]",
+			want:   []string{"app.example.com", "admin.example.com"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Extends test cases in `pkg/subscraping/extractor_test.go` to verify that `RegexSubdomainExtractor` correctly extracts SRV records with underscore prefixes (e.g. `_sip._tcp.example.com`).
- Adds extraction verification for subdomains embedded within bracketed structures like JSON arrays.

### Testing
- Asserts extraction accuracy and preservation of domain boundaries.