### PR TITLE
test(subscraping): add semicolon pipe delimiter and URL path stripped specs

### DIFF
--- a/pkg/subscraping/extractor_test.go
+++ b/pkg/subscraping/extractor_test.go
@@ -73,6 +73,18 @@ func TestRegexSubdomainExtractor_Extract(t *testing.T) {
 			text:   "notexample.com",
 			want:   nil,
 		},
+		{
+			name:   "semicolon and pipe delimited subdomains",
+			domain: "example.com",
+			text:   "dev.example.com;qa.example.com|prod.example.com",
+			want:   []string{"dev.example.com", "qa.example.com", "prod.example.com"},
+		},
+		{
+			name:   "trailing slash and path stripped subdomains",
+			domain: "example.com",
+			text:   "https://dashboard.example.com/login",
+			want:   []string{"dashboard.example.com"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Expands unit test coverage for `RegexSubdomainExtractor` when parsing strings containing common stream/CSV delimiters (semicolons, pipes).
- Verifies proper candidate separation without path leakage.

### Testing
- Asserts extracted subdomains match expected elements without surrounding delimiters.