### PR TITLE
test(subscraping): add port suffix and quote enclosed candidate extraction specs

### DIFF
--- a/pkg/subscraping/extractor_test.go
+++ b/pkg/subscraping/extractor_test.go
@@ -73,6 +73,18 @@ func TestRegexSubdomainExtractor_Extract(t *testing.T) {
 			text:   "notexample.com",
 			want:   nil,
 		},
+		{
+			name:   "subdomains with port suffix",
+			domain: "example.com",
+			text:   "service.example.com:8080 metrics.example.com:9090",
+			want:   []string{"service.example.com", "metrics.example.com"},
+		},
+		{
+			name:   "single and double quote enclosed candidates",
+			domain: "example.com",
+			text:   "'internal.example.com' \"secure.example.com\"",
+			want:   []string{"internal.example.com", "secure.example.com"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Extends test coverage for `RegexSubdomainExtractor` when parsing inputs with port suffixes (`:8080`, `:9090`) and quote boundaries (`'`, `"`).
- Asserts accurate extraction without trailing port fragments or surrounding quotation marks.

### Testing
- Validates clean domain candidate matches across delimited strings.