### PR TITLE
test(subscraping): add multiline CRLF test cases to SubdomainExtractor

### DIFF
--- a/pkg/subscraping/extractor_test.go
+++ b/pkg/subscraping/extractor_test.go
@@ -73,6 +73,12 @@ func TestRegexSubdomainExtractor_Extract(t *testing.T) {
 			text:   "notexample.com",
 			want:   nil,
 		},
+		{
+			name:   "multiline text with windows crlf delimiters",
+			domain: "example.com",
+			text:   "alpha.example.com\r\nbeta.example.com\r\ngamma.other.com",
+			want:   []string{"alpha.example.com", "beta.example.com"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Adds test coverage for `SubdomainExtractor.Extract` when parsing input strings separated by Windows `\r\n` CRLF sequences.
- Validates extraction of valid domains while filtering mismatched apexes across lines.

### Testing
- Validates slice extraction against expected target host list.