### PR TITLE
test(subscraping): add tab and whitespace delimiter specs to SubdomainExtractor

### DIFF
--- a/pkg/subscraping/extractor_test.go
+++ b/pkg/subscraping/extractor_test.go
@@ -73,6 +73,12 @@ func TestRegexSubdomainExtractor_Extract(t *testing.T) {
 			text:   "notexample.com",
 			want:   nil,
 		},
+		{
+			name:   "mixed tabs and whitespace delimiters",
+			domain: "example.com",
+			text:   "one.example.com\t\ttwo.example.com   three.example.com",
+			want:   []string{"one.example.com", "two.example.com", "three.example.com"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Adds test coverage for `SubdomainExtractor.Extract` when parsing input with multiple consecutive tabs and spaces.

### Testing
- Tested against expected target slice.