### PR TITLE
test(subscraping): add comma and semicolon delimited subdomain extraction specs

### DIFF
--- a/pkg/subscraping/extractor_test.go
+++ b/pkg/subscraping/extractor_test.go
@@ -73,6 +73,12 @@ func TestRegexSubdomainExtractor_Extract(t *testing.T) {
 			text:   "notexample.com",
 			want:   nil,
 		},
+		{
+			name:   "comma and semicolon separated subdomain lists",
+			domain: "example.com",
+			text:   "app.example.com,api.example.com;admin.example.com",
+			want:   []string{"app.example.com", "api.example.com", "admin.example.com"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Adds test coverage for `SubdomainExtractor.Extract` with comma and semicolon delimited text inputs.

### Testing
- Tested against expected target slice.