### PR TITLE
test(subscraping): add hyphenated subdomain and domain extraction specs

### DIFF
--- a/pkg/subscraping/extractor_test.go
+++ b/pkg/subscraping/extractor_test.go
@@ -73,6 +73,12 @@ func TestRegexSubdomainExtractor_Extract(t *testing.T) {
 			text:   "notexample.com",
 			want:   nil,
 		},
+		{
+			name:   "hyphenated subdomain and domain names",
+			domain: "my-service.com",
+			text:   "api-prod.my-service.com\nauth-v2.my-service.com",
+			want:   []string{"api-prod.my-service.com", "auth-v2.my-service.com"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Adds unit test verification for `SubdomainExtractor.Extract` parsing hyphenated labels across hostnames and apexes.

### Testing
- Tested against expected target slice.