### PR TITLE
test(subscraping): add punycode internationalized domain extraction specs

### DIFF
--- a/pkg/subscraping/extractor_test.go
+++ b/pkg/subscraping/extractor_test.go
@@ -73,6 +73,12 @@ func TestRegexSubdomainExtractor_Extract(t *testing.T) {
 			text:   "notexample.com",
 			want:   nil,
 		},
+		{
+			name:   "punycode encoded internationalized domain labels",
+			domain: "xn--example-9a.com",
+			text:   "sub.xn--example-9a.com\napi.xn--example-9a.com",
+			want:   []string{"sub.xn--example-9a.com", "api.xn--example-9a.com"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Adds test coverage for `SubdomainExtractor.Extract` parsing punycode-encoded internationalized domain labels (`xn--...`).

### Testing
- Tested against expected target slice.