### PR TITLE
test(subscraping): add leading and trailing dot normalization extraction specs

### DIFF
--- a/pkg/subscraping/extractor_test.go
+++ b/pkg/subscraping/extractor_test.go
@@ -73,6 +73,12 @@ func TestRegexSubdomainExtractor_Extract(t *testing.T) {
 			text:   "notexample.com",
 			want:   nil,
 		},
+		{
+			name:   "subdomains with leading dot and trailing dot variations",
+			domain: "example.com",
+			text:   ".alpha.example.com.\n.beta.example.com.",
+			want:   []string{"alpha.example.com", "beta.example.com"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Adds test coverage for `SubdomainExtractor.Extract` stripping leading and trailing boundary dots around valid subdomains.

### Testing
- Tested against expected target slice.