### PR TITLE
test(subscraping): add JSON string array escaped slash extraction specs

### DIFF
--- a/pkg/subscraping/extractor_test.go
+++ b/pkg/subscraping/extractor_test.go
@@ -73,6 +73,12 @@ func TestRegexSubdomainExtractor_Extract(t *testing.T) {
 			text:   "notexample.com",
 			want:   nil,
 		},
+		{
+			name:   "json encoded string array with escaped slashes",
+			domain: "example.com",
+			text:   "[\"https:\\/\\/alpha.example.com\\/path\", \"https:\\/\\/beta.example.com\\/api\"]",
+			want:   []string{"alpha.example.com", "beta.example.com"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Adds test coverage for `SubdomainExtractor.Extract` parsing JSON string arrays containing escaped forward slashes.

### Testing
- Tested against expected target slice.