### PR TITLE
test(subscraping): add subdomain extraction with trailing port specs

### DIFF
--- a/pkg/subscraping/day2_w17_port_test.go
+++ b/pkg/subscraping/day2_w17_port_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithTrailingPortFilter(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`Host: admin.example.com:8443 and api.example.com:443`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "admin.example.com")
+	assert.Contains(t, results, "api.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` stripping trailing port numbers from matched domain tokens.\n\n### Testing\n- Tested against expected target slice.