### PR TITLE
test(subscraping): add tab-delimited subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day2_w18_tab_test.go
+++ b/pkg/subscraping/day2_w18_tab_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithTabSeparators(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("vpn.example.com\t10.0.0.1\t\tmail.example.com\t10.0.0.2")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "vpn.example.com")
+	assert.Contains(t, results, "mail.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `SubdomainExtractor.Extract` parsing TSV/tab-delimited records.\n\n### Testing\n- Tested against expected target slice.