### PR TITLE
test(subscraping): add CSV record subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day2_w19_csv_test.go
+++ b/pkg/subscraping/day2_w19_csv_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithCommaSeparatedValues(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("id,subdomain,status\n1,auth.example.com,active\n2,gateway.example.com,inactive")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "auth.example.com")
+	assert.Contains(t, results, "gateway.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing RFC-compliant CSV formatted tables.\n\n### Testing\n- Tested against expected target slice.