### PR TITLE
test(subscraping): add NDJSON stream subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day2_w20_ndjson_test.go
+++ b/pkg/subscraping/day2_w20_ndjson_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithNDJSONStream(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("{\"domain\":\"node1.example.com\"}\n{\"domain\":\"node2.example.com\"}\n")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "node1.example.com")
+	assert.Contains(t, results, "node2.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing newline-delimited JSON streams.\n\n### Testing\n- Tested against expected target slice.