### PR TITLE
test(subscraping): add colon-separated key-value subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day2_w21_colon_kv_test.go
+++ b/pkg/subscraping/day2_w21_colon_kv_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithColonSeparatedPairs(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("endpoint:auth-api.example.com\nservice:billing-v2.example.com")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "auth-api.example.com")
+	assert.Contains(t, results, "billing-v2.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing colon-delimited configuration blocks.\n\n### Testing\n- Tested against expected target slice.