### PR TITLE
test(subscraping): add adjacent delimiter domain boundary extraction specs

### DIFF
--- a/pkg/subscraping/day2_w22_domain_boundary_test.go
+++ b/pkg/subscraping/day2_w22_domain_boundary_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithAdjacentDomainBoundaries(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("check(sub1.example.com)and[sub2.example.com];end")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "sub1.example.com")
+	assert.Contains(t, results, "sub2.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing tokens tightly bounded by brackets and parenthesis.\n\n### Testing\n- Tested against expected target slice.