### PR TITLE
test(subscraping): add HTML anchor href subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day2_w23_html_href_test.go
+++ b/pkg/subscraping/day2_w23_html_href_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithHTMLAnchorTags(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`<a href="https://docs.example.com/api">Docs</a><a href="//status.example.com">Status</a>`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "docs.example.com")
+	assert.Contains(t, results, "status.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing subdomains embedded in HTML anchor tags.\n\n### Testing\n- Tested against expected target slice.