### PR TITLE
test(subscraping): add hyphenated multi-level subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day2_w24_hyphen_test.go
+++ b/pkg/subscraping/day2_w24_hyphen_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithHyphenatedSubdomainLabels(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("us-east-1.internal-api.example.com and staging-edge-cdn.example.com")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "us-east-1.internal-api.example.com")
+	assert.Contains(t, results, "staging-edge-cdn.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing hyphenated and nested subdomain hierarchy labels.\n\n### Testing\n- Tested against expected target slice.