### PR TITLE
test(subscraping): add CNAME record subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day2_w25_cname_test.go
+++ b/pkg/subscraping/day2_w25_cname_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithCNAMERecords(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("app.example.com CNAME lb-01.prod.example.com.")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "app.example.com")
+	assert.Contains(t, results, "lb-01.prod.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing DNS CNAME record lines.\n\n### Testing\n- Tested against expected target slice.