### PR TITLE
test(subscraping): add semicolon delimited subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day2_w26_semicolon_test.go
+++ b/pkg/subscraping/day2_w26_semicolon_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithSemicolonSeparators(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("server=edge01.example.com;backup=edge02.example.com;ttl=300")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "edge01.example.com")
+	assert.Contains(t, results, "edge02.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing semicolon-delimited cookie/connection strings.\n\n### Testing\n- Tested against expected target slice.