### PR TITLE
test(subscraping): add URL encoded query parameter subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day2_w27_url_query_test.go
+++ b/pkg/subscraping/day2_w27_url_query_test.go
@@ -1,0 +1,18 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithEmbeddedURLParameters(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("https://tracker.net/pixel?redirect=https%3A%2F%2Fclick.example.com%2Fpath")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "click.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing URL-encoded redirect query values.\n\n### Testing\n- Tested against expected target slice.