### PR TITLE
test(subscraping): add XML CDATA section subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day2_w28_cdata_test.go
+++ b/pkg/subscraping/day2_w28_cdata_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithXMLCDATASections(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("<data><![CDATA[core-hub.example.com and sync.example.com]]></data>")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "core-hub.example.com")
+	assert.Contains(t, results, "sync.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing XML CDATA payload blocks.\n\n### Testing\n- Tested against expected target slice.