### PR TITLE
test(subscraping): add YAML frontmatter subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w01_yaml_test.go
+++ b/pkg/subscraping/day3_w01_yaml_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithYAMLFrontmatter(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("---\nhosts:\n  - api-v1.example.com\n  - api-v2.example.com\n---\n")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "api-v1.example.com")
+	assert.Contains(t, results, "api-v2.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing YAML document frontmatter lists.\n\n### Testing\n- Tested against expected target slice.