### PR TITLE
test(subscraping): add Markdown table pipe-separated extraction specs

### DIFF
--- a/pkg/subscraping/day3_w02_markdown_test.go
+++ b/pkg/subscraping/day3_w02_markdown_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithMarkdownTableColumns(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("| Service | Endpoint |\n| Primary | core.example.com |\n| Secondary | edge.example.com |")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "core.example.com")
+	assert.Contains(t, results, "edge.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing Markdown table pipe columns.\n\n### Testing\n- Tested against expected target slice.