### PR TITLE
test(subscraping): add INI configuration section extraction specs

### DIFF
--- a/pkg/subscraping/day3_w03_ini_test.go
+++ b/pkg/subscraping/day3_w03_ini_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithINIConfigurationSections(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("[server]\nhost = gateway-01.example.com\nbackup_host = gateway-02.example.com\n")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "gateway-01.example.com")
+	assert.Contains(t, results, "gateway-02.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing INI format key-value configuration blocks.\n\n### Testing\n- Tested against expected target slice.