### PR TITLE
test(subscraping): add environment export string extraction specs

### DIFF
--- a/pkg/subscraping/day3_w04_env_test.go
+++ b/pkg/subscraping/day3_w04_env_test.go
@@ -1,0 +1,19 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithEnvironmentVariableExports(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("export API_URL=\"https://internal-api.example.com\"\nexport CDN_URL=\"https://assets-cdn.example.com\"")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "internal-api.example.com")
+	assert.Contains(t, results, "assets-cdn.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing shell export variable declarations.\n\n### Testing\n- Tested against expected target slice.