### PR TITLE
test(subscraping): add Docker Compose label subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w06_docker_test.go
+++ b/pkg/subscraping/day3_w06_docker_test.go
@@ -1,0 +1,18 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithDockerComposeServiceDefinitions(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader("services:\n  web:\n    image: nginx\n    labels:\n      - \"traefik.http.routers.web.rule=Host(\`dashboard.example.com\`)\"")
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "dashboard.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing Docker Compose Traefik router host labels.\n\n### Testing\n- Tested against expected target slice.