### PR TITLE
test(subscraping): add HTML meta tag property subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w08_meta_test.go
+++ b/pkg/subscraping/day3_w08_meta_test.go
@@ -1,0 +1,27 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithHTMLMetaTags(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`
+<!DOCTYPE html>
+<html>
+<head>
+  <meta property="og:url" content="https://auth.example.com/login" />
+  <meta name="twitter:domain" content="portal.example.com" />
+</head>
+</html>
+`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "auth.example.com")
+	assert.Contains(t, results, "portal.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing OpenGraph and Twitter domain HTML meta tags.\n\n### Testing\n- Tested against expected target slice.