### PR TITLE
test(subscraping): add Kubernetes ingress TLS subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w09_k8s_test.go
+++ b/pkg/subscraping/day3_w09_k8s_test.go
@@ -1,0 +1,30 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithK8sIngressTLSDefinitions(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prod-ingress
+spec:
+  tls:
+  - hosts:
+    - secure-gateway.example.com
+    - ingress-lb.example.com
+    secretName: prod-tls-cert
+`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "secure-gateway.example.com")
+	assert.Contains(t, results, "ingress-lb.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing Kubernetes Ingress TLS host manifest definitions.\n\n### Testing\n- Tested against expected target slice.