### PR TITLE
test(subscraping): add OpenAPI 3.0 server URL subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w10_openapi_test.go
+++ b/pkg/subscraping/day3_w10_openapi_test.go
@@ -1,0 +1,28 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithOpenAPIServerDefinitions(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Sample API", "version": "1.0.0" },
+  "servers": [
+    { "url": "https://api-sandbox.example.com/v1" },
+    { "url": "https://staging-gateway.example.com/v1" }
+  ]
+}
+`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "api-sandbox.example.com")
+	assert.Contains(t, results, "staging-gateway.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing OpenAPI 3.0 server definitions.\n\n### Testing\n- Tested against expected target slice.