### PR TITLE
test(subscraping): add Markdown table link URL subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w12_md_test.go
+++ b/pkg/subscraping/day3_w12_md_test.go
@@ -1,0 +1,24 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithMarkdownTableLinks(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`
+| Service | URL |
+|---|---|
+| Admin | [Admin Portal](https://admin-panel.infra.example.com) |
+| Health | [Status Page](https://status-monitor.cloud.example.com) |
+`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "admin-panel.infra.example.com")
+	assert.Contains(t, results, "status-monitor.cloud.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing Markdown table hyperlink URLs.\n\n### Testing\n- Tested against expected target slice.