### PR TITLE
test(subscraping): add Postman collection item URL subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w13_postman_test.go
+++ b/pkg/subscraping/day3_w13_postman_test.go
@@ -1,0 +1,33 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithPostmanCollectionItems(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`
+{
+  "info": { "name": "API Suite" },
+  "item": [
+    {
+      "name": "Auth",
+      "request": {
+        "url": {
+          "raw": "https://identity-gateway.iam.example.com/oauth/token",
+          "host": ["identity-gateway", "iam", "example", "com"]
+        }
+      }
+    }
+  ]
+}
+`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "identity-gateway.iam.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing Postman v2.1 collection URL objects.\n\n### Testing\n- Tested against expected target slice.