### PR TITLE
test(subscraping): add GitLab CI environment URL subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w14_gitlab_test.go
+++ b/pkg/subscraping/day3_w14_gitlab_test.go
@@ -1,0 +1,24 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithGitLabCIEnvironmentURLs(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`
+deploy_review:
+  stage: deploy
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    url: https://review-app-42.stage.example.com
+`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "review-app-42.stage.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing GitLab CI/CD environment manifest deployment URLs.\n\n### Testing\n- Tested against expected target slice.