### PR TITLE
test(subscraping): add Terraform provider endpoint URL subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w15_terraform_test.go
+++ b/pkg/subscraping/day3_w15_terraform_test.go
@@ -1,0 +1,26 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithTerraformProviderConfigs(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`
+provider "aws" {
+  endpoints {
+    s3  = "https://s3-gateway.infra.example.com"
+    ec2 = "https://ec2-control.cloud.example.com"
+  }
+}
+`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "s3-gateway.infra.example.com")
+	assert.Contains(t, results, "ec2-control.cloud.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing Terraform HCL provider custom endpoint URLs.\n\n### Testing\n- Tested against expected target slice.