### PR TITLE
test(subscraping): add Spring Boot properties subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w16_spring_test.go
+++ b/pkg/subscraping/day3_w16_spring_test.go
@@ -1,0 +1,22 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithSpringBootProperties(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`
+spring.datasource.url=jdbc:postgresql://db-cluster.infra.example.com:5432/main
+eureka.client.serviceUrl.defaultZone=https://discovery-registry.cloud.example.com/eureka/
+`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "db-cluster.infra.example.com")
+	assert.Contains(t, results, "discovery-registry.cloud.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing Java Spring Boot application.properties configs.\n\n### Testing\n- Tested against expected target slice.