### PR TITLE
test(subscraping): add Helm values.yaml template subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w17_helm_test.go
+++ b/pkg/subscraping/day3_w17_helm_test.go
@@ -1,0 +1,26 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithHelmChartValues(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`
+global:
+  domain: cluster.example.com
+ingress:
+  hosts:
+    - host: helm-app.prod.example.com
+      paths: ["/"]
+`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "cluster.example.com")
+	assert.Contains(t, results, "helm-app.prod.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing Helm chart values template definitions.\n\n### Testing\n- Tested against expected target slice.