### PR TITLE
test(subscraping): add Consul service catalog subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w18_consul_test.go
+++ b/pkg/subscraping/day3_w18_consul_test.go
@@ -1,0 +1,29 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithConsulServiceCatalog(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`
+[
+  {
+    "Node": "consul-node-1",
+    "Address": "10.1.1.1",
+    "ServiceID": "payment-api",
+    "ServiceName": "payment-service",
+    "ServiceAddress": "pay-gateway.prod.example.com",
+    "ServicePort": 8443
+  }
+]
+`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "pay-gateway.prod.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing HashiCorp Consul catalog payload objects.\n\n### Testing\n- Tested against expected target slice.