### PR TITLE
test(subscraping): add CircleCI config orb domain subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w19_circleci_test.go
+++ b/pkg/subscraping/day3_w19_circleci_test.go
@@ -1,0 +1,28 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithCircleCIConfigOrbs(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`
+version: 2.1
+orbs:
+  deploy: circleci/aws-s3@3.0.0
+jobs:
+  build:
+    environment:
+      DEPLOY_HOST: "circle-deploy.infra.example.com"
+      ARTIFACT_BUCKET: "https://build-artifacts.s3.example.com"
+`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "circle-deploy.infra.example.com")
+	assert.Contains(t, results, "build-artifacts.s3.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing CircleCI configuration YAML environments.\n\n### Testing\n- Tested against expected target slice.