### PR TITLE
test(subscraping): add Chef cookbook attribute subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w20_chef_test.go
+++ b/pkg/subscraping/day3_w20_chef_test.go
@@ -1,0 +1,22 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithChefCookbookAttributes(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`
+default['app']['master_node'] = 'chef-master.infra.example.com'
+default['app']['repo_url'] = 'https://pkg-repo.prod.example.com/yum'
+`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "chef-master.infra.example.com")
+	assert.Contains(t, results, "pkg-repo.prod.example.com")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `SubdomainExtractor.Extract` parsing Chef Ruby cookbook attribute configuration strings.\n\n### Testing\n- Tested against expected target slice.