### PR TITLE
test(subscraping): add Ansible inventory host subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w21_ansible_test.go
+++ b/pkg/subscraping/day3_w21_ansible_test.go
@@ -1,0 +1,23 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithAnsibleInventoryHosts(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`
+[webservers]
+web-alpha.prod.example.com ansible_host=10.0.1.10
+web-beta.prod.example.com ansible_host=10.0.1.11
+`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "web-alpha.prod.example.com")
+	assert.Contains(t, results, "web-beta.prod.example.com")
+}


### PR DESCRIPTION
### Summary
- Adds test coverage for  parsing Ansible inventory host strings.

### Testing
- Tested against expected target slice.