### PR TITLE
test(subscraping): add Puppet manifest node subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w22_puppet_test.go
+++ b/pkg/subscraping/day3_w22_puppet_test.go
@@ -1,0 +1,26 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWithPuppetManifestNodes(t *testing.T) {
+	extractor, err := NewSubdomainExtractor("example.com")
+	assert.Nil(t, err)
+
+	body := strings.NewReader(`
+node 'db-primary.infra.example.com' {
+  include role::database
+}
+node 'cache-cluster.prod.example.com' {
+  include role::redis
+}
+`)
+	results := extractor.Extract(body)
+
+	assert.Contains(t, results, "db-primary.infra.example.com")
+	assert.Contains(t, results, "cache-cluster.prod.example.com")
+}


### PR DESCRIPTION
### Summary
- Adds test coverage for SubdomainExtractor parsing Puppet manifest node definitions.

### Testing
- Tested against expected target slice.