### PR TITLE
test(subscraping): add DNS TXT record SPF subdomain extraction specs

### DIFF
--- a/pkg/subscraping/day3_w23_spf_test.go
+++ b/pkg/subscraping/day3_w23_spf_test.go
@@ -1,0 +1,21 @@
+package subscraping
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSPFSubdomainExtractionW23(t *testing.T) {
+	record := "v=spf1 include:_spf.example.com include:mail.target.com -all"
+	parts := strings.Fields(record)
+	var includes []string
+	for _, p := range parts {
+		if strings.HasPrefix(p, "include:") {
+			includes = append(includes, strings.TrimPrefix(p, "include:"))
+		}
+	}
+	assert.Equal(t, 2, len(includes))
+	assert.Equal(t, "_spf.example.com", includes[0])
+}


### PR DESCRIPTION
### Summary
- Adds unit test verification for extracting referenced domain tokens from SPF DNS TXT record payloads.

### Testing
- Tested with testify/assert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated coverage for SPF subdomain extraction.
  - Verifies that SPF include directives are correctly identified, normalized, and returned in the expected order.
  - Improves confidence in subscription scraping behavior when processing SPF records with multiple included domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->